### PR TITLE
fix a bug about operationlist's name item converted to utf8 twice.

### DIFF
--- a/libpgmodeler_ui/src/operationlistwidget.cpp
+++ b/libpgmodeler_ui/src/operationlistwidget.cpp
@@ -82,7 +82,7 @@ void OperationListWidget::updateOperationList(void)
 			item2=new QTreeWidgetItem(item);
 			item2->setIcon(0,QPixmap(QString(":/icones/icones/uid.png")));
 			item2->setFont(0,font);
-			item2->setText(0,Utf8String::create(trUtf8("Name: %1").arg(obj_name)));
+			item2->setText(0,trUtf8("Name: %1").arg(Utf8String::create(obj_name)));
 
 			if(op_type==Operation::OBJECT_CREATED)
 			{


### PR DESCRIPTION
"Name: %1" was translated to other language.But converted to utf8 again by Utf8String::create.
zh_CN.ts is as follows:
    <message>
        <source>Name: %1</source>
        <translation>名称：%1</translation>
    </message>
but "???public.new_table" was displayed in operation list.
