### PR TITLE
Set mainwindow -> File menu -> Save All invalid default

### DIFF
--- a/libpgmodeler_ui/ui/mainwindow.ui
+++ b/libpgmodeler_ui/ui/mainwindow.ui
@@ -685,6 +685,9 @@
    </property>
   </action>
   <action name="action_save_all">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="text">
     <string>Save all</string>
    </property>


### PR DESCRIPTION
When start pgModeler with no model opened,file menu -> save all should be invalid(can't click).
