### PR TITLE
Disable colored grep to fix substring operations

### DIFF
--- a/linuxdeploy.sh
+++ b/linuxdeploy.sh
@@ -1,5 +1,8 @@
 #/bin/bash
 
+alias grep="grep --color=never"
+shopt -s expand_aliases
+
 QMAKE_ROOT=/usr/bin
 FALLBACK_QMAKE_ROOT=/usr/local/qt-5.0.2/5.0.2/gcc_64/bin
 LOG=linuxdeploy.log


### PR DESCRIPTION
I have grep alias with --color=auto in .bashc by default in my Ubuntu installation.

It looks like linuxdeploy.sh fails to work with colored grep, particularly bash substring {::} is  working incorrectly.

To fix this I've added this code in the beginning of linuxdeploy.sh:

``` bash
alias grep="grep --color=never"
shopt -s expand_aliases
```

Can this be added to linuxdeploy.sh? Or it is not pgmodeler-related issue and I need to set up my env/aliases by myself.

Thanks.
