### PR TITLE
Add support for retina display mac

### DIFF
--- a/main/res/Info.plist
+++ b/main/res/Info.plist
@@ -36,5 +36,7 @@
        <string>0.7.0-pre</string>
        <key>CSResourcesFileMapped</key>
        <true/>
+       <key>NSHighResolutionCapable</key>
+       <string>True</string>
     </dict>
 </plist>


### PR DESCRIPTION
Allows the app to be rendered properly on retina display macs. Everything appears to display correctly (and look much better).

Still needs 2x resolution icons/images, but I haven't looked into that.
