### PR TITLE
Fix "make install" on linux (Fix issue #649).

### DIFF
--- a/pgmodeler.pro
+++ b/pgmodeler.pro
@@ -28,16 +28,16 @@ SUBDIRS += crashhandler \
            main
 
 # Deployment settings
-samples.files = samples
+samples.files = samples/*
 samples.path = $$SAMPLESDIR
 
-schemas.files = schemas
+schemas.files = schemas/*
 schemas.path = $$SCHEMASDIR
 
-lang.files = lang
+lang.files = lang/*
 lang.path = $$LANGDIR
 
-conf.files = conf
+conf.files = conf/*
 conf.path = $$CONFDIR
 
 doc.files = README.md CHANGELOG.md LICENSE RELEASENOTES.md


### PR DESCRIPTION
Make use recursive copy, "cp -f -R", to install source files
"conf, lang, samples, and schemas" to $SHAREDIR. The problem is if CONFDIR
is empty then the default destination directory is $SHAREDIR/conf, but
when make install is execute it will copy source directory "conf" to
$SHAREDIR/conf/conf, not content of "conf" dir.