### PR TITLE
ModelObjectWidget changed keyboard and focus behaviour.

### DIFF
--- a/libpgmodeler_ui/src/modelobjectswidget.h
+++ b/libpgmodeler_ui/src/modelobjectswidget.h
@@ -95,7 +95,9 @@ class ModelObjectsWidget: public QWidget, public Ui::ModelObjectsWidget {
 		void resizeEvent(QResizeEvent *);
 		void closeEvent(QCloseEvent *);
 		void showEvent(QShowEvent *);
+        void keyPressEvent(QKeyEvent *event);
     bool eventFilter(QObject *object, QEvent *event);
+        bool passEventToFilterEdit(QEvent *event);
 
   public:
 		ModelObjectsWidget(bool simplified_view=false, QWidget * parent = 0);


### PR DESCRIPTION
Switching focus form filter edit to tree/table by pressing arrows up/down key.
Added event filter for tree/table and widget, printed symbols + backspace update filter edit.
