### PR TITLE
Creation of underlying UDT of another composite UDT while importing m…

### DIFF
--- a/main/src/application.cpp
+++ b/main/src/application.cpp
@@ -187,3 +187,12 @@ void Application::copyFilesRecursively(const QString &src_path, const QString &d
 						__PRETTY_FUNCTION__,__FILE__,__LINE__);
 	}
 }
+
+Application::~Application(void)
+{
+    // workaround to prevent app crash while exiting
+    // as per https://bugreports.qt.io/browse/QTBUG-56448
+    QColorDialog colorDlg(0);
+    colorDlg.setOption(QColorDialog::NoButtons);
+    colorDlg.setCurrentColor(Qt::white);
+}

--- a/main/src/application.h
+++ b/main/src/application.h
@@ -39,6 +39,7 @@
 #include <QTextStream>
 #include <QTranslator>
 #include <QFile>
+#include <QtWidgets>
 
 class Application: public QApplication {
 	private:
@@ -52,6 +53,7 @@ class Application: public QApplication {
 	public:
 		Application(int & argc, char ** argv);
 		bool notify(QObject * receiver, QEvent * event);
+        virtual ~Application(void);
 };
 
 #endif


### PR DESCRIPTION
Quite dumb fix for issue #883 in 0.9.0 branch: checks if UDT is not base one and not loaded into model. If it's not loads UDT using code similar to dependency object creation.

If anyone can advise how to get UDT as one record by schema and name correctly I'd appreciate that.

Fix works but obviously it needs to be more elegant.