### PR TITLE
Begin implementation of "scroll to zoom" functionality

### DIFF
--- a/libpgmodeler_ui/src/modelwidget.cpp
+++ b/libpgmodeler_ui/src/modelwidget.cpp
@@ -91,6 +91,7 @@ ModelWidget::ModelWidget(QWidget *parent) : QWidget(parent)
 							 BaseRelationship::RELATIONSHIP_GEN };
 
 	current_zoom=1;
+	zoom_on_scroll=1; // @etosan: temporary, I have no clue how to connect this to GUI
 	modified=panning_mode=false;
 	new_obj_type=BASE_OBJECT;
 
@@ -441,7 +442,7 @@ bool ModelWidget::eventFilter(QObject *object, QEvent *event)
 	QGraphicsSceneMouseEvent *m_event = dynamic_cast<QGraphicsSceneMouseEvent *>(event);
 
 	//Filters the Wheel event if it is raised by the viewport scrollbars
-	if(event->type() == QEvent::Wheel && w_event->modifiers()==Qt::ControlModifier)
+	if(event->type() == QEvent::Wheel && (zoom_on_scroll || w_event->modifiers()==Qt::ControlModifier) )
 	{
 		//Redirects the event to the wheelEvent() method of the model widget
 		this->wheelEvent(w_event);
@@ -535,12 +536,19 @@ void ModelWidget::mousePressEvent(QMouseEvent *event)
 
 void ModelWidget::wheelEvent(QWheelEvent * event)
 {
-	if(event->modifiers()==Qt::ControlModifier)
-	{
+	if(zoom_on_scroll || event->modifiers()==Qt::ControlModifier) {
+		int numDegrees = abs(event->delta()/8);
+		int numSteps = numDegrees/15;
+		double newZoom = ZOOM_INCREMENT * numSteps;
+
 		if(event->delta() < 0)
-			this->applyZoom(this->current_zoom - ZOOM_INCREMENT);
-		else
-			this->applyZoom(this->current_zoom + ZOOM_INCREMENT);
+		{
+			this->applyZoom(this->current_zoom - newZoom);
+		}
+		else if(event->delta() > 0)
+		{
+			this->applyZoom(this->current_zoom + newZoom);
+		}
 	}
 }
 

--- a/libpgmodeler_ui/src/modelwidget.h
+++ b/libpgmodeler_ui/src/modelwidget.h
@@ -47,6 +47,9 @@ class ModelWidget: public QWidget {
 		//! \brief Indicates if the model was modified by some operation
 		bool modified,
 
+		zoom_on_scroll,
+		//! \brief Indicates whether we want to zoom by default when user rolls the mousewheel
+
 		//! brief Indicates if the panning mode was activated via event filter (see eventFilter())
 		panning_mode;
 


### PR DESCRIPTION
Intent of this tiny change is to modify "database overview" model
in such a way, that "scroll to zoom" behaviour is possible.

Changes made affect these two files:
	modified:   libpgmodeler_ui/src/modelwidget.cpp
	modified:   libpgmodeler_ui/src/modelwidget.h

These changes finalize modifications to ease navigation in large
projects with standard, 3-button and scroll wheel enabled mouse.

Users now can zoom in and out and pan around the database really
quickly. This is also immensely useful, when analyzing already
existing databases with big numbers of tables.

Code expects this behaviour to be toggleable, given some users
might be used to "scroll wheel to pan up and down" in some
environments, on some platforms.

Second phase would be adding gui toggle into the preferences
dialog and code to config file praser. Although I tried really
hard, I was unable to modify both the gui or config parsing
on my machine.

Quick zoomability also uncovered new tiny glitch as well,
where in small database models, database view ends up in
upper left corner, when fully zoomed out. This can get
pretty confusing on high zoom out levels.

It would be preferrable instead, if model remained centered
to the pgmodeler window, when zooming out too far.
Unfortunately I don't understand the code well enough to do
that either, but I am recording my intent in this commit.