### PR TITLE
Use gcc to determine multiarch library directory

### DIFF
--- a/linuxdeploy.sh
+++ b/linuxdeploy.sh
@@ -258,8 +258,14 @@ if [ $BUNDLE_QT_LIBS = 1 ]; then
  
  QT_ROOT=`$QMAKE_ROOT/qtpaths --install-prefix`  >> $LOG 2>&1
  
+ LIB_DIR=
+ MULTIARCH=`gcc -print-multiarch` >> $LOG 2>&1
+ if [ -n "$MULTIARCH" ]; then
+   LIB_DIR="$MULTIARCH/"
+ fi
+
  for lib in $QT_LIBS; do
-  cp -v $QT_ROOT/lib/$lib $BUILD_DIR/$INSTALL_ROOT/lib >> $LOG 2>&1
+  cp -v $QT_ROOT/lib/$LIB_DIR$lib $BUILD_DIR/$INSTALL_ROOT/lib >> $LOG 2>&1
  done
  
  if [ $? -ne 0 ]; then


### PR DESCRIPTION
On a multiarch system, QT libraries reside in a subdirectory of /usr/lib
with a name that depends on the architecture which results in a failing
deploy. By using the gcc interface the directory name can be resolved.