### PR TITLE
This change makes pgmodeler ignore precision attributes which are too…

### DIFF
--- a/libpgmodeler/src/pgsqltypes.cpp
+++ b/libpgmodeler/src/pgsqltypes.cpp
@@ -1584,7 +1584,8 @@ QString PgSQLType::getCodeDefinition(unsigned def_type,QString ref_type)
 		if(dimension > 0)
 			attribs[ParsersAttributes::DIMENSION]=QString("%1").arg(this->dimension);
 
-		if(precision >= 0)
+		if(precision >= 0 &&
+		   precision < 1000000) // Ignore rubbish precision values.
 			attribs[ParsersAttributes::PRECISION]=QString("%1").arg(this->precision);
 
 		if(interval_type != BaseType::null)


### PR DESCRIPTION
… big, so they are removed on the next save.

Bizarre precision attribute values are saved by pgmodeler on every save, probably due to uninitialized values. If the precision attribute is completly ommited, it  won't show this behavior because it wll not be present.

These precision attributes are irrelevant when they present themselves, as they are anyways ignored
by the software, and it carries on with no consequence. But, they present a big problem for version
control systems, as they obfuscate the patches: suppose you do a minimal change, like changing a
GRANT for a table. Then you save and commit. Instead of seeing in the changeset (of the XML)  only
the change for the GRANT, you see tens or hundreds of these precision attributes changing as well,
which are annoying, make it unclear what was really intendended to change, and add unnecesary
information to the history of the file.