### PR TITLE
Fix window scaling on HiDPI/Retina screens

### DIFF
--- a/libobjrenderer/src/baseobjectview.cpp
+++ b/libobjrenderer/src/baseobjectview.cpp
@@ -639,9 +639,10 @@ double BaseObjectView::getFontFactor(void)
 double BaseObjectView::getScreenDpiFactor(void)
 {
 	double factor = qApp->screens().at(qApp->desktop()->screenNumber(qApp->activeWindow()))->logicalDotsPerInch() / 96.0f;
+  double pixel_ratio = qApp->screens().at(qApp->desktop()->screenNumber(qApp->activeWindow()))->devicePixelRatio();
 
 	if(factor < 1)
 		return (1);
 
-	return(factor);
+	return(factor * pixel_ratio);
 }

--- a/libobjrenderer/src/basetableview.cpp
+++ b/libobjrenderer/src/basetableview.cpp
@@ -351,13 +351,14 @@ void BaseTableView::__configureObject(float width)
 		QPen pen = ext_attribs_body->pen();
 		float py = 0;
 		float factor = qApp->screens().at(qApp->desktop()->screenNumber(qApp->activeWindow()))->logicalDotsPerInch() / 96.0f;
+    float pixel_ratio = qApp->screens().at(qApp->desktop()->screenNumber(qApp->activeWindow()))->devicePixelRatio();
 
 		ext_attribs_toggler->setVisible(true);
 		ext_attribs_tog_arrow->setVisible(true);
 
 		ext_attribs_toggler->setPen(pen);
 		ext_attribs_toggler->setBrush(ext_attribs_body->brush());
-		ext_attribs_toggler->setRect(QRectF(0, 0, width, 12 * factor));
+		ext_attribs_toggler->setRect(QRectF(0, 0, width, 12 * factor * pixel_ratio));
 
 		if(!tab->isExtAttribsHidden())
 		{
@@ -378,14 +379,14 @@ void BaseTableView::__configureObject(float width)
 		if(!tab->isExtAttribsHidden())
 		{
 			pol.append(QPointF(0,0));
-			pol.append(QPointF(-5 * factor, 6 * factor));
-			pol.append(QPointF(5 * factor, 6 * factor));
+			pol.append(QPointF(-5 * factor * pixel_ratio, 6 * factor * pixel_ratio));
+			pol.append(QPointF(5 * factor * pixel_ratio, 6 * factor * pixel_ratio));
 		}
 		else
 		{
-			pol.append(QPointF(0,6 * factor));
-			pol.append(QPointF(-5 * factor, 0));
-			pol.append(QPointF(5 * factor, 0));
+			pol.append(QPointF(0,6 * factor * pixel_ratio));
+			pol.append(QPointF(-5 * factor * pixel_ratio, 0));
+			pol.append(QPointF(5 * factor * pixel_ratio, 0));
 		}
 
 		QLinearGradient grad(QPointF(0,0),QPointF(0,1));

--- a/libpgmodeler_ui/src/baseform.cpp
+++ b/libpgmodeler_ui/src/baseform.cpp
@@ -46,10 +46,12 @@ void BaseForm::resizeForm(QWidget *widget)
 			screen_id = qApp->desktop()->screenNumber(qApp->activeWindow());
 	QScreen *screen=qApp->screens().at(screen_id);
 	float dpi_factor = 0;
+  float pixel_ratio = 0;
 
 	max_w = screen->size().width() * 0.70;
 	max_h = screen->size().height() * 0.70;
 	dpi_factor = screen->logicalDotsPerInch() / 96.0f;
+  pixel_ratio = screen->devicePixelRatio();
 
 	if(dpi_factor <= 1.01f)
 		dpi_factor = 1.0f;
@@ -102,8 +104,8 @@ void BaseForm::resizeForm(QWidget *widget)
 							((buttons_lt->contentsMargins().top() +
 								buttons_lt->contentsMargins().bottom()) * 6);
 
-	curr_w *= dpi_factor;
-	curr_h *= dpi_factor;
+	curr_w *= dpi_factor * pixel_ratio;
+	curr_h *= dpi_factor * pixel_ratio;
 
 	if(curr_w > screen->size().width())
 		curr_w = screen->size().width() * 0.80;

--- a/libpgmodeler_ui/src/pgmodeleruins.cpp
+++ b/libpgmodeler_ui/src/pgmodeleruins.cpp
@@ -279,8 +279,10 @@ namespace PgModelerUiNS {
 				screen_id = qApp->desktop()->screenNumber(qApp->activeWindow());
 		QScreen *screen=qApp->screens().at(screen_id);
 		float dpi_factor = 0;
+    float pixel_ratio = 0;
 
 		dpi_factor = screen->logicalDotsPerInch() / 96.0f;
+    pixel_ratio = screen->devicePixelRatio();
 
 		//If the dpi_factor is unchanged (1) we keep the dialog original dimension
 		if(dpi_factor <= 1.01f)
@@ -307,8 +309,8 @@ namespace PgModelerUiNS {
 		else if(min_size.height() >= max_h)
 			curr_h = max_h;
 
-		curr_w *= dpi_factor;
-		curr_h *= dpi_factor;
+		curr_w *= dpi_factor * pixel_ratio;
+		curr_h *= dpi_factor * pixel_ratio;
 
 		if(curr_w > screen->size().width())
 			curr_w = screen->size().width() * 0.80;


### PR DESCRIPTION
@rkhaotix Leveraging the `QScreen->devicePixelRatio()` `const` (introduced in Qt 5.5) to make window scaling correct on HiDPI/Retina screens. What do you think?

I no longer mess around with low-pixel-density screens, so I haven't tested this on one. Please try on yours.

Here is a screenshot from my Desktop in 3840x2160 (using a 2:1 pixel density ratio, so the "logical" window size is 1920x1080):

<img width="1920" alt="screen shot 2018-04-19 at 8 41 07 am" src="https://user-images.githubusercontent.com/4141828/39003838-8f632a0a-43b0-11e8-8492-e3cea1190293.png">

_Zoom in and/or download screen shot to see it is 3840 × 2160 pixels._


With these edits I can **finally** see more than 2 rows and get LARGE DIALOG WINDOWS!!!!!!!!!