### PR TITLE
Use existing column for references

### DIFF
--- a/libpgmodeler/src/relationship.h
+++ b/libpgmodeler/src/relationship.h
@@ -300,6 +300,8 @@ class Relationship: public BaseRelationship {
 		GenTabToken, //{gt}
 		SrcColToken; //{sc}
 
+		bool useExisting;
+
 		//! \brief Patterns ids
 		static constexpr unsigned SrcColPattern=0,
 		DstColPattern=1,

--- a/libpgmodeler_ui/src/modeldatabasediffform.cpp
+++ b/libpgmodeler_ui/src/modeldatabasediffform.cpp
@@ -1027,7 +1027,7 @@ void ModelDatabaseDiffForm::selectOutputFile(void)
 void ModelDatabaseDiffForm::selectOutputMigrationFolder(void)
 {
 	QString dir = QFileDialog::getExistingDirectory(this, tr("Open Directory"),
-							"/home",
+							QProcessEnvironment::systemEnvironment().value("HOME", "/home"),
 							QFileDialog::ShowDirsOnly);
 	migration_folder_edt->setText(dir);
 }

--- a/libpgmodeler_ui/src/modeldatabasediffform.cpp
+++ b/libpgmodeler_ui/src/modeldatabasediffform.cpp
@@ -392,6 +392,8 @@ void ModelDatabaseDiffForm::enableDiffMode(void)
 	store_in_file_wgt->setEnabled(store_in_file_rb->isChecked());
 	store_as_migration_wgt->setEnabled(store_as_migration_rb->isChecked());
 
+	migration_folder_edt->setText(laravelMigrationFolderSetting());
+
 	generate_btn->setEnabled(database_cmb->currentIndex() > 0 &&
 						((src_database_rb->isChecked() && src_database_cmb->currentIndex() > 0) ||
 							(src_model_rb->isChecked() && loaded_model)) &&
@@ -1024,10 +1026,32 @@ void ModelDatabaseDiffForm::selectOutputFile(void)
 	}
 }
 
+QString ModelDatabaseDiffForm::laravelMigrationFolderSetting(QString value)
+{
+	QString home_folder = QProcessEnvironment::systemEnvironment().value("HOME", "/home");
+	QString config_file_path = home_folder + "/.config/pgmodeler/laravel_migration.conf";
+	QString setting_key = "previous_directory";
+	QSettings settings(config_file_path, QSettings::NativeFormat);
+	if (value == "")
+	{
+		QString past_folder = settings.value(setting_key, "").toString();
+		if (past_folder == "")
+			past_folder = home_folder;
+
+		return past_folder;
+	}
+	else
+	{
+		settings.setValue(setting_key, value);
+		return "";
+	}
+}
+
 void ModelDatabaseDiffForm::selectOutputMigrationFolder(void)
 {
 	QString dir = QFileDialog::getExistingDirectory(this, tr("Open Directory"),
-							QProcessEnvironment::systemEnvironment().value("HOME", "/home"),
+							laravelMigrationFolderSetting(),
 							QFileDialog::ShowDirsOnly);
+	laravelMigrationFolderSetting(dir);
 	migration_folder_edt->setText(dir);
 }

--- a/libpgmodeler_ui/src/modeldatabasediffform.cpp
+++ b/libpgmodeler_ui/src/modeldatabasediffform.cpp
@@ -618,10 +618,10 @@ void ModelDatabaseDiffForm::saveDiffToFile(void)
 	if(!sqlcode_txt->toPlainText().isEmpty())
 	{
 		QFile output;
-        	QString laravel_migration,
+		QString laravel_migration,
 			up,
 			down;
-		if (store_as_migration_rb->isChecked() != "")
+		if (store_as_migration_rb->isChecked())
 			{
 				laravel_migration = "<?php\n\
 \n\

--- a/libpgmodeler_ui/src/modeldatabasediffform.h
+++ b/libpgmodeler_ui/src/modeldatabasediffform.h
@@ -135,6 +135,7 @@ class ModelDatabaseDiffForm: public QDialog, public Ui::ModelDatabaseDiffForm {
 		void handleErrorIgnored(QString err_code, QString err_msg, QString cmd);
 		void selectOutputFile(void);
 		void selectOutputMigrationFolder(void);
+		QString laravelMigrationFolderSetting(QString value = "");
 		void importDatabase(unsigned thread_id);
 		void diffModels(void);
 		void exportDiff(bool confirm=true);

--- a/libpgmodeler_ui/src/modeldatabasediffform.h
+++ b/libpgmodeler_ui/src/modeldatabasediffform.h
@@ -134,6 +134,7 @@ class ModelDatabaseDiffForm: public QDialog, public Ui::ModelDatabaseDiffForm {
 		void handleExportFinished(void);
 		void handleErrorIgnored(QString err_code, QString err_msg, QString cmd);
 		void selectOutputFile(void);
+		void selectOutputMigrationFolder(void);
 		void importDatabase(unsigned thread_id);
 		void diffModels(void);
 		void exportDiff(bool confirm=true);

--- a/libpgmodeler_ui/src/relationshipwidget.cpp
+++ b/libpgmodeler_ui/src/relationshipwidget.cpp
@@ -406,6 +406,7 @@ void RelationshipWidget::setAttributes(DatabaseModel *model, OperationList *op_l
 	table2_mand_chk->setVisible(rel1n);
 
 	identifier_wgt->setVisible(rel1n && !base_rel->isSelfRelationship());
+	use_existing_wgt->setVisible(rel1n && !base_rel->isSelfRelationship());
 	foreign_key_gb->setVisible(rel1n || relnn);
 	single_pk_wgt->setVisible(relnn);
 
@@ -1087,7 +1088,17 @@ void RelationshipWidget::applyConfiguration(void)
 
 			rel=dynamic_cast<Relationship *>(base_rel);
 
-			if(name_patterns_grp->isVisible())
+			if (use_existing_chk->isChecked())
+			{
+				rel->useExisting = use_existing_chk->isChecked();
+			}
+			else
+			{
+				rel->useExisting = false;
+			}
+
+			// shemgp: apply defaults even if name_patterns_grp is not visible
+			// if(name_patterns_grp->isVisible())
 			{
 				count=sizeof(pattern_ids)/sizeof(unsigned);
 				for(i=0; i < count; i++)

--- a/libpgmodeler_ui/ui/modeldatabasediffform.ui
+++ b/libpgmodeler_ui/ui/modeldatabasediffform.ui
@@ -523,7 +523,7 @@
                       <string>Store in S&amp;QL file</string>
                      </property>
                      <property name="checked">
-                      <bool>true</bool>
+                      <bool>false</bool>
                      </property>
                     </widget>
                    </item>
@@ -654,6 +654,85 @@
                     </item>
                    </layout>
                   </widget>
+                 </item>
+                 <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout_2">
+                   <item>
+                    <widget class="QRadioButton" name="store_as_migration_rb">
+                     <property name="statusTip">
+                      <string>Compares input vs Compare to and outputs a Laravel migration file.</string>
+                     </property>
+                     <property name="text">
+                      <string>Store as Laravel migration</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="horizontalSpacer_9">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>40</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <layout class="QHBoxLayout" name="store_as_migration_wgt">
+                   <property name="leftMargin">
+                    <number>9</number>
+                   </property>
+                   <item>
+                    <widget class="QLabel" name="label_2">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="statusTip">
+                      <string>Class name in Camel Case</string>
+                     </property>
+                     <property name="text">
+                      <string>Class:</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLineEdit" name="migration_class_edt"/>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="label_4">
+                     <property name="text">
+                      <string>Folder:</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLineEdit" name="migration_folder_edt"/>
+                   </item>
+                   <item>
+                    <widget class="QToolButton" name="select_migration_file_tb">
+                     <property name="acceptDrops">
+                      <bool>false</bool>
+                     </property>
+                     <property name="toolTip">
+                      <string>Select Laravel migration File</string>
+                     </property>
+                     <property name="text">
+                      <string>...</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
                  </item>
                  <item>
                   <layout class="QHBoxLayout" name="horizontalLayout_8">

--- a/libpgmodeler_ui/ui/relationshipwidget.ui
+++ b/libpgmodeler_ui/ui/relationshipwidget.ui
@@ -331,6 +331,25 @@
           </spacer>
          </item>
          <item>
+          <widget class="QWidget" name="use_existing_wgt" native="true">
+           <layout class="QHBoxLayout" name="horizontalLayout_6">
+            <item>
+             <widget class="QCheckBox" name="use_existing_chk">
+              <property name="statusTip">
+               <string>Use existing columns when linking.</string>
+              </property>
+              <property name="text">
+               <string>Use Existing</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
           <widget class="QWidget" name="identifier_wgt" native="true">
            <property name="minimumSize">
             <size>


### PR DESCRIPTION
Here's a way to quickly link two tables together when columns exists but only the relationship needs to be added.

I added a "Use Existing" checkbox to the relationship view and I just look if it is checked and don't create the column in the `recv_tab` when the same column exists already.

Btw, I also removed `if(name_patterns_grp->isVisible())` since it doesn't allow me to use the defaults when the "Settings" tab is not clicked when clicking "Apply".

May be it can be a fix for: #451.
