### PR TITLE
0.9.2 alpha1 Allow a way to use existing column when linking tables

### DIFF
--- a/libpgmodeler/src/relationship.h
+++ b/libpgmodeler/src/relationship.h
@@ -300,6 +300,8 @@ class Relationship: public BaseRelationship {
 		GenTabToken, //{gt}
 		SrcColToken; //{sc}
 
+		bool useExisting;
+
 		//! \brief Patterns ids
 		static constexpr unsigned SrcColPattern=0,
 		DstColPattern=1,

--- a/libpgmodeler_ui/src/relationshipwidget.cpp
+++ b/libpgmodeler_ui/src/relationshipwidget.cpp
@@ -406,6 +406,7 @@ void RelationshipWidget::setAttributes(DatabaseModel *model, OperationList *op_l
 	table2_mand_chk->setVisible(rel1n);
 
 	identifier_wgt->setVisible(rel1n && !base_rel->isSelfRelationship());
+	use_existing_wgt->setVisible(rel1n && !base_rel->isSelfRelationship());
 	foreign_key_gb->setVisible(rel1n || relnn);
 	single_pk_wgt->setVisible(relnn);
 
@@ -1087,7 +1088,17 @@ void RelationshipWidget::applyConfiguration(void)
 
 			rel=dynamic_cast<Relationship *>(base_rel);
 
-			if(name_patterns_grp->isVisible())
+			if (use_existing_chk->isChecked())
+			{
+				rel->useExisting = use_existing_chk->isChecked();
+			}
+			else
+			{
+				rel->useExisting = false;
+			}
+
+			// shemgp: apply defaults even if name_patterns_grp is not visible
+			// if(name_patterns_grp->isVisible())
 			{
 				count=sizeof(pattern_ids)/sizeof(unsigned);
 				for(i=0; i < count; i++)

--- a/libpgmodeler_ui/ui/relationshipwidget.ui
+++ b/libpgmodeler_ui/ui/relationshipwidget.ui
@@ -331,6 +331,25 @@
           </spacer>
          </item>
          <item>
+          <widget class="QWidget" name="use_existing_wgt" native="true">
+           <layout class="QHBoxLayout" name="horizontalLayout_6">
+            <item>
+             <widget class="QCheckBox" name="use_existing_chk">
+              <property name="statusTip">
+               <string>Use existing columns when linking.</string>
+              </property>
+              <property name="text">
+               <string>Use Existing</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
           <widget class="QWidget" name="identifier_wgt" native="true">
            <property name="minimumSize">
             <size>


### PR DESCRIPTION
Here's a way to quickly link two tables together when columns exists but only the relationship needs to be added.

I added a "Use Existing" checkbox to the relationship view and I just look if it is checked and don't create the column in the recv_tab when the same column exists already.

Btw, I also removed if(name_patterns_grp->isVisible()) since it doesn't allow me to use the defaults when the "Settings" tab is not clicked when clicking "Apply".

May be it can be a fix for: #451.