### PR TITLE
Fix: put views after tables when getting code definition

### DIFF
--- a/libpgmodeler_ui/src/modelsdiffhelper.cpp
+++ b/libpgmodeler_ui/src/modelsdiffhelper.cpp
@@ -644,6 +644,8 @@ void ModelsDiffHelper::processDiffInfos(void)
 	Table *parent_tab=nullptr;
 	bool skip_obj=false;
 	QStringList sch_names;
+	map<unsigned, QString> create_view_objs, alter_view_objs;
+	unsigned largest_object_id = 0;
 
 	try
 	{
@@ -674,6 +676,7 @@ void ModelsDiffHelper::processDiffInfos(void)
 			diff_type=diff.getDiffType();
 			object=diff.getObject();
 			obj_type=object->getObjectType();
+			//qDebug("processDiffInfos:%s[%d] = %s", qUtf8Printable(object->getTypeName()), object->getObjectId(), qUtf8Printable(object->getName()));
 			rel=dynamic_cast<Relationship *>(object);
 			constr=dynamic_cast<Constraint *>(object);
 			col=dynamic_cast<Column *>(object);
@@ -764,7 +767,16 @@ void ModelsDiffHelper::processDiffInfos(void)
 					}
 					else
 					{
-						create_objs[object->getObjectId()]=getCodeDefinition(object, false);
+						if (object->getObjectType() == ObjectType::View)
+						{
+							create_view_objs[object->getObjectId()]=getCodeDefinition(object, false);
+						}
+						else
+						{
+							if (object->getObjectId() > largest_object_id)
+								largest_object_id = object->getObjectId();
+							create_objs[object->getObjectId()]=getCodeDefinition(object, false);
+						}
 
 						if(obj_type==ObjectType::Schema)
 							sch_names.push_back(object->getName(true));
@@ -803,7 +815,16 @@ void ModelsDiffHelper::processDiffInfos(void)
 									create_constrs[obj->getObjectId()]=getCodeDefinition(obj, false);
 							}
 							else
-								create_objs[obj->getObjectId()]=getCodeDefinition(obj, false);
+								if (object->getObjectType() == ObjectType::View)
+								{
+									alter_view_objs[obj->getObjectId()]=getCodeDefinition(obj, false);
+								}
+								else
+								{
+									if (object->getObjectId() > largest_object_id)
+										largest_object_id = obj->getObjectId();
+									create_objs[obj->getObjectId()]=getCodeDefinition(obj, false);
+								}
 						}
 					}
 
@@ -841,6 +862,12 @@ void ModelsDiffHelper::processDiffInfos(void)
 				}
 			}
 		}
+
+		for(auto &object: create_view_objs)
+			create_objs[largest_object_id + object.first] = object.second;
+		for(auto &object: alter_view_objs)
+			create_objs[largest_object_id + object.first] = object.second;
+
 
 		//Creating the shell types declaration right below on the DDL that creates their schemas
 		for(Type *type : types)


### PR DESCRIPTION
Here's a fix for my bug report #1253 and probably #922 as well.

I added incrementing counters to the map id per "group of objects" so that the order will be retained.  And I also had to skip adding the `View` objects to object_map when adding `Table`s.  This forces views to be after the table when calling `getCodeDefintiion`.

Feel free to update the code; eg. make it non-repetitive if need be.