### PR TITLE
Subitem multiselection

### DIFF
--- a/libobjrenderer/src/baseobjectview.cpp
+++ b/libobjrenderer/src/baseobjectview.cpp
@@ -399,10 +399,19 @@ QVariant BaseObjectView::itemChange(GraphicsItemChange change, const QVariant &v
 	else if(change == ItemSelectedHasChanged && obj_selection)
 	{
 		this->setSelectionOrder(value.toBool());
-		pos_info_item->setVisible(value.toBool());
-		obj_selection->setVisible(value.toBool());
 
-		this->configurePositionInfo(this->pos());
+		obj_selection->setVisible(value.toBool());
+		if(pos_info_item)
+		{
+			pos_info_item->setVisible(value.toBool());
+			this->configurePositionInfo(this->pos());
+		}
+		emit s_objectSelected(dynamic_cast<BaseGraphicObject *>(this->getSourceObject()), value.toBool());
+	}
+
+	else if(change == ItemSelectedHasChanged && this->getSourceObject()->getObjectType()==ObjectType::Column && value.toBool()==false)
+	{
+		this->setSelectionOrder(value.toBool());
 		emit s_objectSelected(dynamic_cast<BaseGraphicObject *>(this->getSourceObject()), value.toBool());
 	}
 

--- a/libobjrenderer/src/basetableview.cpp
+++ b/libobjrenderer/src/basetableview.cpp
@@ -28,6 +28,7 @@ BaseTableView::BaseTableView(BaseTable *base_tab) : BaseObjectView(base_tab)
 		throw Exception(ErrorCode::AsgNotAllocattedObject, __PRETTY_FUNCTION__, __FILE__, __LINE__);
 
 	pending_geom_update = false;
+	is_ungrouped=false;
 	body=new RoundedRectItem;
 	body->setRoundedCorners(RoundedRectItem::BottomLeftCorner | RoundedRectItem::BottomRightCorner);
 
@@ -154,12 +155,29 @@ void BaseTableView::mousePressEvent(QGraphicsSceneMouseEvent *event)
 
 		emit s_childObjectSelected(sel_child_obj);
 	}
+
+	//If intended selection of a subitem
+	else if(this->isSelected() && event->buttons()==Qt::LeftButton && sel_child_obj &&
+			!is_ungrouped && QGuiApplication::queryKeyboardModifiers() & Qt::ShiftModifier)
+	{
+		this->ungroupCols();
+
+		//Get a grip on the tableobjectview item that was just hovered :
+		//we match on baseobject names within the columns of this table.
+		//Then select it.
+		for(int i=0;i< this->ungrouped_cols.size();i++)
+		{
+			if(sel_child_obj->getName()==
+						dynamic_cast<BaseObjectView *>(this->ungrouped_cols[i])->getSourceObject()->getName())
+				this->ungrouped_cols[i]->setSelected(true);
+		}
+	}
 	else
 	{
 		QPointF pnt = attribs_toggler->mapFromScene(event->scenePos());
 
 		//If the user clicks the extended attributes toggler
-		if(!this->isSelected() && event->buttons()==Qt::LeftButton &&
+		if(event->buttons()==Qt::LeftButton &&
 			 attribs_toggler->isVisible() && attribs_toggler->boundingRect().contains(pnt))
 			attribs_toggler->setButtonSelected(pnt, true);
 
@@ -197,7 +215,7 @@ void BaseTableView::hoverMoveEvent(QGraphicsSceneHoverEvent *event)
 {
 	/* Case the table itself is not selected shows the child selector
 		at mouse position */
-	if(!this->isSelected())
+	if(!this->is_ungrouped)
 	{
 		QList<QGraphicsItem *> items;
 		double cols_height, item_idx, ext_height=0;
@@ -234,19 +252,22 @@ void BaseTableView::hoverMoveEvent(QGraphicsSceneHoverEvent *event)
 		{
 			BaseObjectView *item=dynamic_cast<TableObjectView *>(items[static_cast<int>(item_idx)]);
 
-			//Configures the selection with the item's dimension
-			if(obj_selection->boundingRect().height() != item->boundingRect().height())
+			if(!this->isSelected())
 			{
-				dynamic_cast<RoundedRectItem *>(obj_selection)->setBorderRadius(2);
-				dynamic_cast<RoundedRectItem *>(obj_selection)->setRect(QRectF(0, 0,
-																																			 title->boundingRect().width() - (2.5 * HorizSpacing),
-																																			 item->boundingRect().height() - VertSpacing));
-			}
+				//Configures the selection with the item's dimension
+				if(obj_selection->boundingRect().height()!=item->boundingRect().height())
+				{
+					dynamic_cast<RoundedRectItem *>(obj_selection)->setBorderRadius(2);
+					dynamic_cast<RoundedRectItem *>(obj_selection)->setRect(QRectF(0, 0,
+																																				 title->boundingRect().width() - (2.5 * HorizSpacing),
+																																				 item->boundingRect().height() - VertSpacing));
+				}
 
-			//Sets the selection position as same as item's position
-			rect1=this->mapRectToItem(item, item->boundingRect());
-			obj_selection->setVisible(true);
-			obj_selection->setPos(QPointF(title->pos().x() + HorizSpacing, -rect1.top() + VertSpacing/2));
+				//Sets the selection position as same as item's position
+				rect1=this->mapRectToItem(item, item->boundingRect());
+				obj_selection->setVisible(true);
+				obj_selection->setPos(QPointF(title->pos().x() + HorizSpacing, -rect1.top() + VertSpacing/2));
+			}
 
 			//Stores the selected child object
 			sel_child_obj=dynamic_cast<TableObject *>(item->getSourceObject());
@@ -507,16 +528,33 @@ bool BaseTableView::configurePaginationParams(unsigned section_id, unsigned tota
 
 void BaseTableView::configureCollapsedSections(CollapseMode coll_mode)
 {
+	if(is_ungrouped)
+	{
+		this->scene()->clearSelection();
+		this->checkRegroupCols();
+	}
+
 	startGeometryUpdate();
 	dynamic_cast<BaseTable *>(this->getSourceObject())->setCollapseMode(coll_mode);
 	finishGeometryUpdate();
 	emit s_collapseModeChanged();
+
+	// Using a single shot time to restore the selectable flag
+	QTimer::singleShot(500, [&]{
+		this->scene()->clearSelection();
+		QKeyEvent *event = new QKeyEvent ( QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
+		QCoreApplication::postEvent(scene(), event);});
 }
 
 void BaseTableView::togglePagination(bool enabled)
 {
 	BaseTable *tab = dynamic_cast<BaseTable *>(this->getSourceObject());
 
+	if(is_ungrouped)
+	{
+		this->scene()->clearSelection();
+		this->checkRegroupCols();
+	}
 	startGeometryUpdate();
 	tab->setPaginationEnabled(enabled);
 	tab->resetCurrentPages();
@@ -530,4 +568,51 @@ void BaseTableView::configureCurrentPage(unsigned section_id, unsigned page)
 	dynamic_cast<BaseTable *>(this->getSourceObject())->setCurrentPage(section_id, page);
 	finishGeometryUpdate();
 	emit s_currentPageChanged();
+}
+
+void BaseTableView::ungroupCols()
+{
+	QList<QGraphicsItem *> cols = this->columns->childItems();
+	ungrouped_cols.clear();
+
+	this->setFlag(QGraphicsItem::ItemIsMovable, false);
+	for(auto & col : cols)
+	{
+		auto * subitem = dynamic_cast<TableObjectView *>(col);
+		subitem->setFlag(QGraphicsItem::ItemIsMovable, false);
+		subitem->setFlag(QGraphicsItem::ItemIsSelectable, true);
+		this->columns->removeFromGroup(subitem);
+		this->removeFromGroup(subitem);
+		ungrouped_cols.append(subitem);
+	}
+	this->is_ungrouped=true;
+	this->setSelected(false);
+}
+
+void BaseTableView::checkRegroupCols()
+{
+	if(!is_ungrouped) return;
+
+	for(auto & ungrouped_col : ungrouped_cols)
+	{
+		if(ungrouped_col->isSelected()) return;
+	}
+
+	for (auto subitem : ungrouped_cols)
+	{
+		this->columns->addToGroup(subitem);
+		subitem->setFlag(QGraphicsItem::ItemIsMovable, true);
+	}
+
+	ungrouped_cols.clear();
+	this->is_ungrouped=false;
+	this->setSelected(false);
+	this->setFlag(QGraphicsItem::ItemIsMovable, true);
+}
+
+void BaseTableView::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget * widget)
+{
+	painter->setPen(Qt::NoPen);
+	painter->setBrush(Qt::NoBrush);
+	QGraphicsItemGroup::paint(painter,option,widget);
 }

--- a/libobjrenderer/src/basetableview.h
+++ b/libobjrenderer/src/basetableview.h
@@ -48,10 +48,16 @@ class BaseTableView: public BaseObjectView {
 		 * to false and the geometry updated immediately (see BaseTableView::itemChange()) */
 		bool pending_geom_update;
 
+		//! \brief Flag up if a subitem multiselection is happening and cols are ungrouped.
+		bool is_ungrouped;
+
 		//! \brief Item groups that stores columns and extended attributes, respectively
 		QGraphicsItemGroup *columns,
 
 		*ext_attribs;
+
+		//! \brief Container holding track of the temporary top-level ungrouped tableObjectViews
+		QList<TableObjectView *> ungrouped_cols;
 
 		//! brief Indicates if the extended attributes body should be hidden
 		static bool hide_ext_attribs,
@@ -158,6 +164,13 @@ class BaseTableView: public BaseObjectView {
 
 		//! \brief Configures the shadow for the table
 		void configureObjectShadow(void);
+		//! \brief Set the columns top-level for subitem multiselection.
+		void ungroupCols(void);
+
+		//! \brief Regroup columns if ungrouped.
+		void checkRegroupCols(void);
+
+		void paint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *) override;
 
 	private slots:
 		/*! \brief This slot reconfigures the table when the attributes toggler emits the signal s_collapseModeChanged

--- a/libobjrenderer/src/objectsscene.cpp
+++ b/libobjrenderer/src/objectsscene.cpp
@@ -1019,6 +1019,13 @@ void ObjectsScene::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 			//Case the user starts a object moviment
 			if(sel_items_count != 0 && !moving_objs)
 			{
+                //Cancel the operation if any ungrouped columns is selected
+                for (const auto &item:this->selectedItems())
+                {
+                    if(dynamic_cast<TableObjectView *>(item)!=nullptr)
+                        return;
+                }
+
 				if(BaseObjectView::isPlaceholderEnabled())
 				{
 					QList<QGraphicsItem *> items=this->selectedItems();

--- a/libobjrenderer/src/tableobjectview.h
+++ b/libobjrenderer/src/tableobjectview.h
@@ -46,10 +46,7 @@ class TableObjectView: public BaseObjectView
 		 has a constraint */
 		void configureDescriptor(ConstraintType constr_type=BaseType::Null);
 
-		QVariant itemChange(GraphicsItemChange, const QVariant &value)
-		{
-			return(value);
-		}
+		QVariant itemChange(GraphicsItemChange change, const QVariant &value);
 
 		void calculateBoundingRect(void);
 
@@ -92,12 +89,14 @@ class TableObjectView: public BaseObjectView
 		 that is applyed to the passed column */
 		static QString getConstraintString(Column *column);
 
-		virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr);
+		void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr) override;
 
 		virtual QRectF boundingRect(void) const;
 
 		void configureObjectShadow(void) = delete;
 		void configureObjectSelection(void) = delete;
+
+		friend class TableView;
 };
 
 #endif

--- a/libobjrenderer/src/tableview.cpp
+++ b/libobjrenderer/src/tableview.cpp
@@ -218,6 +218,7 @@ void TableView::configureObject(void)
 			subitems.pop_front();
 			col_item->setChildObjectXPos(TableObjectView::ConstrAliasLabel,
 																	 width - col_item->getChildObject(TableObjectView::ConstrAliasLabel)->boundingRect().width() - (2 * HorizSpacing) - 1);
+			col_item->bounding_rect.setWidth(width - 2*HorizSpacing);
 
 			//Generating the connection points of the columns
 			if(obj_idx==0)

--- a/libpgmodeler_ui/src/modelwidget.cpp
+++ b/libpgmodeler_ui/src/modelwidget.cpp
@@ -1018,19 +1018,14 @@ void ModelWidget::handleObjectModification(BaseGraphicObject *object)
 
 void ModelWidget::emitSceneInteracted(void)
 {
-	if(selected_objects.empty())
+	if(scene->selectedItems().empty())
 		emit s_sceneInteracted(nullptr);
-	else if(selected_objects.size() == 1)
+	else if(scene->selectedItems().size() == 1)
 	{
-		BaseGraphicObject *base_obj = dynamic_cast<BaseGraphicObject *>(selected_objects[0]);
-
-		if(base_obj)
-			emit s_sceneInteracted(dynamic_cast<BaseObjectView *>(base_obj->getReceiverObject()));
-		else
-			emit s_sceneInteracted(nullptr);
+			emit s_sceneInteracted(dynamic_cast<BaseObjectView *>(scene->selectedItems()[0]));
 	}
 	else
-		emit s_sceneInteracted(selected_objects.size(), scene->itemsBoundingRect(true, true));
+		emit s_sceneInteracted(scene->selectedItems().size(), scene->itemsBoundingRect(true, true));
 }
 
 void ModelWidget::configureObjectSelection(void)


### PR DESCRIPTION
This is the subitem multiselection feature rebased and naked.

There is still code you made a comment on earlier : https://github.com/pgmodeler/pgmodeler/pull/1233#discussion_r250300264 .

Added one line to have the ability to click on the attribute toggler item even when the basetable is already selected, I find it much more convenient!

BR, Maxime