### PR TITLE
Alternative implementation for #1368 using singleton.

### DIFF
--- a/crashhandler/src/crashhandlerform.cpp
+++ b/crashhandler/src/crashhandlerform.cpp
@@ -44,9 +44,9 @@ CrashHandlerForm::CrashHandlerForm(bool analysis_mode, QWidget *parent, Qt::Wind
 	report_twg->addTab(wgt, trUtf8("Stack trace"));
 
 	//Open for reading the stack trace file generated on the last crash
-	input.setFileName(GlobalAttributes::TemporaryDir +
-					  GlobalAttributes::DirSeparator +
-					  GlobalAttributes::StacktraceFile);
+	input.setFileName(GlobalAttributes::get().TemporaryDir +
+					  GlobalAttributes::get().DirSeparator +
+					  GlobalAttributes::get().StacktraceFile);
 	input.open(QFile::ReadOnly);
 
 	if(input.isOpen())
@@ -56,9 +56,9 @@ CrashHandlerForm::CrashHandlerForm(bool analysis_mode, QWidget *parent, Qt::Wind
 
 		//Removes the stack trace file
 		QDir stack_file;
-		stack_file.remove(GlobalAttributes::TemporaryDir +
-						  GlobalAttributes::DirSeparator +
-						  GlobalAttributes::StacktraceFile);
+		stack_file.remove(GlobalAttributes::get().TemporaryDir +
+						  GlobalAttributes::get().DirSeparator +
+						  GlobalAttributes::get().StacktraceFile);
 
 		//Shows the stacktrace loaded on the widget
 		stack_txt->setPlainText(buf);

--- a/crashhandler/src/main.cpp
+++ b/crashhandler/src/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv)
 		QTranslator translator;
 
 		//Loads the ui translation for crashhandler
-		translator.load(QLocale::system().name(), GlobalAttributes::LanguagesDir);
+		translator.load(QLocale::system().name(), GlobalAttributes::get().LanguagesDir);
 		app.installTranslator(&translator);
 
 		CrashHandlerForm crashhandler(args.size() > 1 && args[1]==CrashHandlerForm::AnalysisMode);

--- a/libobjrenderer/src/baseobjectview.cpp
+++ b/libobjrenderer/src/baseobjectview.cpp
@@ -40,7 +40,7 @@ BaseObjectView::BaseObjectView(BaseObject *object)
 }
 
 BaseObjectView::~BaseObjectView(void)
-{  
+{
 	setSourceObject(nullptr);
 }
 
@@ -163,19 +163,19 @@ void BaseObjectView::loadObjectsStyle(void)
 	map<QString, QTextCharFormat>::iterator itr;
 	QStringList list;
 	QString elem,
-			config_file=GlobalAttributes::ConfigurationsDir + GlobalAttributes::DirSeparator +
-						GlobalAttributes::ObjectsStyleConf + GlobalAttributes::ConfigurationExt;
+			config_file=GlobalAttributes::get().ConfigurationsDir + GlobalAttributes::get().DirSeparator +
+						GlobalAttributes::get().ObjectsStyleConf + GlobalAttributes::get().ConfigurationExt;
 	XmlParser xmlparser;
 
 	try
 	{
 		xmlparser.restartParser();
-		xmlparser.setDTDFile(GlobalAttributes::TmplConfigurationDir +
-							 GlobalAttributes::DirSeparator +
-							 GlobalAttributes::ObjectDTDDir +
-							 GlobalAttributes::DirSeparator +
-							 GlobalAttributes::ObjectsStyleConf +
-							 GlobalAttributes::ObjectDTDExt, GlobalAttributes::ObjectsStyleConf);
+		xmlparser.setDTDFile(GlobalAttributes::get().TmplConfigurationDir +
+							 GlobalAttributes::get().DirSeparator +
+							 GlobalAttributes::get().ObjectDTDDir +
+							 GlobalAttributes::get().DirSeparator +
+							 GlobalAttributes::get().ObjectsStyleConf +
+							 GlobalAttributes::get().ObjectDTDExt, GlobalAttributes::get().ObjectsStyleConf);
 		xmlparser.loadXMLFile(config_file);
 
 		if(xmlparser.accessElement(XmlParser::ChildElement))

--- a/libparsers/src/schemaparser.cpp
+++ b/libparsers/src/schemaparser.cpp
@@ -908,8 +908,8 @@ QString SchemaParser::getCodeDefinition(const QString & obj_name, attribs_map &a
 		if(def_type==SqlDefinition)
 		{
 			//Formats the filename
-			filename=GlobalAttributes::SchemasRootDir + GlobalAttributes::DirSeparator +
-					 GlobalAttributes::SQLSchemaDir + GlobalAttributes::DirSeparator + obj_name + GlobalAttributes::SchemaExt;
+			filename=GlobalAttributes::get().SchemasRootDir + GlobalAttributes::get().DirSeparator +
+					 GlobalAttributes::get().SQLSchemaDir + GlobalAttributes::get().DirSeparator + obj_name + GlobalAttributes::get().SchemaExt;
 
 			attribs[Attributes::PgSqlVersion]=pgsql_version;
 
@@ -918,9 +918,9 @@ QString SchemaParser::getCodeDefinition(const QString & obj_name, attribs_map &a
 		}
 		else
 		{
-			filename=GlobalAttributes::SchemasRootDir + GlobalAttributes::DirSeparator +
-					 GlobalAttributes::XMLSchemaDir + GlobalAttributes::DirSeparator + obj_name +
-					 GlobalAttributes::SchemaExt;
+			filename=GlobalAttributes::get().SchemasRootDir + GlobalAttributes::get().DirSeparator +
+					 GlobalAttributes::get().XMLSchemaDir + GlobalAttributes::get().DirSeparator + obj_name +
+					 GlobalAttributes::get().SchemaExt;
 
 			return(convertCharsToXMLEntities(getCodeDefinition(filename, attribs)));
 		}

--- a/libpgconnector/src/catalog.cpp
+++ b/libpgconnector/src/catalog.cpp
@@ -161,9 +161,9 @@ void Catalog::loadCatalogQuery(const QString &qry_id)
 	if(catalog_queries.count(qry_id)==0)
 	{
 		QFile input;
-		input.setFileName(GlobalAttributes::SchemasRootDir + GlobalAttributes::DirSeparator +
-							CatalogSchemasDir + GlobalAttributes::DirSeparator +
-							qry_id + GlobalAttributes::SchemaExt);
+		input.setFileName(GlobalAttributes::get().SchemasRootDir + GlobalAttributes::get().DirSeparator +
+							CatalogSchemasDir + GlobalAttributes::get().DirSeparator +
+							qry_id + GlobalAttributes::get().SchemaExt);
 
 		if(!input.open(QFile::ReadOnly))
 			throw Exception(Exception::getErrorMessage(ErrorCode::FileDirectoryNotAccessed).arg(input.fileName()),

--- a/libpgmodeler/src/baseobject.cpp
+++ b/libpgmodeler/src/baseobject.cpp
@@ -791,9 +791,9 @@ QString BaseObject::getCodeDefinition(unsigned def_type, bool reduced_form)
 				if(obj_type!=ObjectType::Tablespace && obj_type!=ObjectType::Database && obj_type!=ObjectType::UserMapping)
 				{
 					SchemaParser sch_parser;
-					QString filename=GlobalAttributes::SchemasRootDir + GlobalAttributes::DirSeparator +
-									 GlobalAttributes::AlterSchemaDir + GlobalAttributes::DirSeparator +
-									 Attributes::Owner + GlobalAttributes::SchemaExt;
+					QString filename=GlobalAttributes::get().SchemasRootDir + GlobalAttributes::get().DirSeparator +
+									 GlobalAttributes::get().AlterSchemaDir + GlobalAttributes::get().DirSeparator +
+									 Attributes::Owner + GlobalAttributes::get().SchemaExt;
 
 					sch_parser.ignoreUnkownAttributes(true);
 					attributes[Attributes::Owner]=sch_parser.getCodeDefinition(filename, attributes);
@@ -1222,9 +1222,9 @@ QString BaseObject::getAlterDefinition(QString sch_name, attribs_map &attribs, b
 	try
 	{
 		SchemaParser schparser;
-		QString alter_sch_dir=GlobalAttributes::SchemasRootDir + GlobalAttributes::DirSeparator +
-								GlobalAttributes::AlterSchemaDir + GlobalAttributes::DirSeparator +
-								QString("%1") + GlobalAttributes::SchemaExt;
+		QString alter_sch_dir=GlobalAttributes::get().SchemasRootDir + GlobalAttributes::get().DirSeparator +
+								GlobalAttributes::get().AlterSchemaDir + GlobalAttributes::get().DirSeparator +
+								QString("%1") + GlobalAttributes::get().SchemaExt;
 
 		schparser.setPgSQLVersion(BaseObject::pgsql_ver);
 		schparser.ignoreEmptyAttributes(ignore_empty_attribs);

--- a/libpgmodeler/src/databasemodel.cpp
+++ b/libpgmodeler/src/databasemodel.cpp
@@ -372,9 +372,9 @@ void DatabaseModel::__addObject(BaseObject *object, int obj_idx)
 #ifdef DEMO_VERSION
 #warning "DEMO VERSION: database model object creation limit."
 	obj_list=getObjectList(obj_type);
-	if(obj_list && obj_list->size() >= GlobalAttributes::MaxObjectCount)
+	if(obj_list && obj_list->size() >= GlobalAttributes::get().MaxObjectCount)
 		throw Exception(trUtf8("The demonstration version can create only `%1' instances of each object type! You've reach this limit for the type: `%2'")
-						.arg(GlobalAttributes::MaxObjectCount)
+						.arg(GlobalAttributes::get().MaxObjectCount)
 						.arg(BaseObject::getTypeName(obj_type)),
 						ErrorCode::Custom,__PRETTY_FUNCTION__,__FILE__,__LINE__);
 
@@ -3178,12 +3178,12 @@ void DatabaseModel::loadModel(const QString &filename)
 		map<ObjectType, QString> def_objs;
 
 		//Configuring the path to the base path for objects DTD
-		dtd_file=GlobalAttributes::SchemasRootDir +
-				 GlobalAttributes::DirSeparator +
-				 GlobalAttributes::XMLSchemaDir +
-				 GlobalAttributes::DirSeparator +
-				 GlobalAttributes::ObjectDTDDir +
-				 GlobalAttributes::DirSeparator;
+		dtd_file=GlobalAttributes::get().SchemasRootDir +
+				 GlobalAttributes::get().DirSeparator +
+				 GlobalAttributes::get().XMLSchemaDir +
+				 GlobalAttributes::get().DirSeparator +
+				 GlobalAttributes::get().ObjectDTDDir +
+				 GlobalAttributes::get().DirSeparator;
 
 		try
 		{
@@ -3191,9 +3191,9 @@ void DatabaseModel::loadModel(const QString &filename)
 			xmlparser.restartParser();
 
 			//Loads the root DTD
-			xmlparser.setDTDFile(dtd_file + GlobalAttributes::RootDTD +
-								 GlobalAttributes::ObjectDTDExt,
-								 GlobalAttributes::RootDTD);
+			xmlparser.setDTDFile(dtd_file + GlobalAttributes::get().RootDTD +
+								 GlobalAttributes::get().ObjectDTDExt,
+								 GlobalAttributes::get().RootDTD);
 
 			//Loads the file validating it against the root DTD
 			xmlparser.loadXMLFile(filename);
@@ -7392,7 +7392,7 @@ QString DatabaseModel::getCodeDefinition(unsigned def_type, bool export_file)
 
 		attribs_aux[Attributes::SearchPath]=search_path;
 		attribs_aux[Attributes::ModelAuthor]=author;
-		attribs_aux[Attributes::PgModelerVersion]=GlobalAttributes::PgModelerVersion;
+		attribs_aux[Attributes::PgModelerVersion]=GlobalAttributes::get().PgModelerVersion;
 
 		if(def_type==SchemaParser::XmlDefinition)
 		{
@@ -10291,7 +10291,7 @@ void DatabaseModel::saveObjectsMetadata(const QString &filename, unsigned option
 			attribs[Attributes::SqlDisabled]=(save_objs_sqldis && object->isSQLDisabled() && !object->isSystemObject()  ? Attributes::True : QString());
 			attribs[Attributes::Tag]=(save_tags && base_tab && base_tab->getTag() ? base_tab->getTag()->getName() : QString());
 			attribs[Attributes::AppendedSql]=object->getAppendedSQL();
-			attribs[Attributes::PrependedSql]=object->getPrependedSQL();			
+			attribs[Attributes::PrependedSql]=object->getPrependedSQL();
 			attribs[Attributes::FadedOut]=(save_fadeout && graph_obj && graph_obj->isFadedOut() ? Attributes::True : QString());
 			attribs[Attributes::CollapseMode]=(save_collapsemode && base_tab ? QString::number(enum_cast(base_tab->getCollapseMode())) : QString());
 
@@ -10309,7 +10309,7 @@ void DatabaseModel::saveObjectsMetadata(const QString &filename, unsigned option
 
 			//Configuring database model attributes
 			if(save_db_attribs && object==this)
-			{			
+			{
 				attribs[Attributes::ModelAuthor]=this->getAuthor();
 				attribs[Attributes::LastPosition]=QString("%1,%2").arg(last_pos.x()).arg(last_pos.y());
 				attribs[Attributes::LastZoom]=QString::number(last_zoom);
@@ -10349,9 +10349,9 @@ void DatabaseModel::saveObjectsMetadata(const QString &filename, unsigned option
 					{
 						schparser.ignoreUnkownAttributes(true);
 						attribs[Attributes::Position]=
-								schparser.getCodeDefinition(GlobalAttributes::SchemasRootDir + GlobalAttributes::DirSeparator +
-																						GlobalAttributes::XMLSchemaDir + GlobalAttributes::DirSeparator +
-																						Attributes::Position + GlobalAttributes::SchemaExt, attribs);
+								schparser.getCodeDefinition(GlobalAttributes::get().SchemasRootDir + GlobalAttributes::get().DirSeparator +
+																						GlobalAttributes::get().XMLSchemaDir + GlobalAttributes::get().DirSeparator +
+																						Attributes::Position + GlobalAttributes::get().SchemaExt, attribs);
 					}
 				}
 				else
@@ -10376,9 +10376,9 @@ void DatabaseModel::saveObjectsMetadata(const QString &filename, unsigned option
 
 						schparser.ignoreUnkownAttributes(true);
 						attribs[Attributes::Position]+=
-								schparser.getCodeDefinition(GlobalAttributes::SchemasRootDir + GlobalAttributes::DirSeparator +
-																						GlobalAttributes::XMLSchemaDir + GlobalAttributes::DirSeparator +
-																						Attributes::Position + GlobalAttributes::SchemaExt, attribs);
+								schparser.getCodeDefinition(GlobalAttributes::get().SchemasRootDir + GlobalAttributes::get().DirSeparator +
+																						GlobalAttributes::get().XMLSchemaDir + GlobalAttributes::get().DirSeparator +
+																						Attributes::Position + GlobalAttributes::get().SchemaExt, attribs);
 					}
 
 					//Saving the labels' custom positions
@@ -10391,13 +10391,13 @@ void DatabaseModel::saveObjectsMetadata(const QString &filename, unsigned option
 							aux_attribs[Attributes::YPos]=QString::number(pnt.y());
 							aux_attribs[Attributes::RefType]=labels_attrs[id];
 
-							aux_attribs[Attributes::Position]=schparser.getCodeDefinition(GlobalAttributes::SchemasRootDir + GlobalAttributes::DirSeparator +
-																																									 GlobalAttributes::XMLSchemaDir + GlobalAttributes::DirSeparator +
-																																									 Attributes::Position + GlobalAttributes::SchemaExt, aux_attribs);
+							aux_attribs[Attributes::Position]=schparser.getCodeDefinition(GlobalAttributes::get().SchemasRootDir + GlobalAttributes::get().DirSeparator +
+																																									 GlobalAttributes::get().XMLSchemaDir + GlobalAttributes::get().DirSeparator +
+																																									 Attributes::Position + GlobalAttributes::get().SchemaExt, aux_attribs);
 
-							attribs[Attributes::Position]+=schparser.getCodeDefinition(GlobalAttributes::SchemasRootDir + GlobalAttributes::DirSeparator +
-																																								GlobalAttributes::XMLSchemaDir + GlobalAttributes::DirSeparator +
-																																								Attributes::Label + GlobalAttributes::SchemaExt, aux_attribs);
+							attribs[Attributes::Position]+=schparser.getCodeDefinition(GlobalAttributes::get().SchemasRootDir + GlobalAttributes::get().DirSeparator +
+																																								GlobalAttributes::get().XMLSchemaDir + GlobalAttributes::get().DirSeparator +
+																																								Attributes::Label + GlobalAttributes::get().SchemaExt, aux_attribs);
 						}
 					}
 				}
@@ -10407,14 +10407,14 @@ void DatabaseModel::saveObjectsMetadata(const QString &filename, unsigned option
 			if(save_custom_sql)
 			{
 				if(!object->getAppendedSQL().isEmpty())
-					attribs[Attributes::AppendedSql]=schparser.getCodeDefinition(GlobalAttributes::SchemasRootDir + GlobalAttributes::DirSeparator +
-																																							 GlobalAttributes::XMLSchemaDir + GlobalAttributes::DirSeparator +
-																																							 QString(Attributes::AppendedSql).remove(QChar('-')) + GlobalAttributes::SchemaExt, attribs);
+					attribs[Attributes::AppendedSql]=schparser.getCodeDefinition(GlobalAttributes::get().SchemasRootDir + GlobalAttributes::get().DirSeparator +
+																																							 GlobalAttributes::get().XMLSchemaDir + GlobalAttributes::get().DirSeparator +
+																																							 QString(Attributes::AppendedSql).remove(QChar('-')) + GlobalAttributes::get().SchemaExt, attribs);
 
 				if(!object->getPrependedSQL().isEmpty())
-					attribs[Attributes::PrependedSql]=schparser.getCodeDefinition(GlobalAttributes::SchemasRootDir + GlobalAttributes::DirSeparator +
-																																								GlobalAttributes::XMLSchemaDir + GlobalAttributes::DirSeparator +
-																																								QString(Attributes::PrependedSql).remove(QChar('-')) + GlobalAttributes::SchemaExt, attribs);
+					attribs[Attributes::PrependedSql]=schparser.getCodeDefinition(GlobalAttributes::get().SchemasRootDir + GlobalAttributes::get().DirSeparator +
+																																								GlobalAttributes::get().XMLSchemaDir + GlobalAttributes::get().DirSeparator +
+																																								QString(Attributes::PrependedSql).remove(QChar('-')) + GlobalAttributes::get().SchemaExt, attribs);
 			}
 
 			/* The object's metadata code will be generated only if one of the key attributes
@@ -10441,9 +10441,9 @@ void DatabaseModel::saveObjectsMetadata(const QString &filename, unsigned option
 
 				schparser.ignoreUnkownAttributes(true);
 				objs_def+=schparser.convertCharsToXMLEntities(
-										schparser.getCodeDefinition(GlobalAttributes::SchemasRootDir + GlobalAttributes::DirSeparator +
-																							GlobalAttributes::XMLSchemaDir + GlobalAttributes::DirSeparator +
-																							Attributes::Info + GlobalAttributes::SchemaExt, attribs));
+										schparser.getCodeDefinition(GlobalAttributes::get().SchemasRootDir + GlobalAttributes::get().DirSeparator +
+																							GlobalAttributes::get().XMLSchemaDir + GlobalAttributes::get().DirSeparator +
+																							Attributes::Info + GlobalAttributes::get().SchemaExt, attribs));
 			}
 			else
 				idx++;
@@ -10455,9 +10455,9 @@ void DatabaseModel::saveObjectsMetadata(const QString &filename, unsigned option
 		{
 			//Generates the metadata XML buffer
 			attribs[Attributes::Info]=objs_def;
-			buf.append(schparser.getCodeDefinition(GlobalAttributes::SchemasRootDir + GlobalAttributes::DirSeparator +
-																						 GlobalAttributes::XMLSchemaDir + GlobalAttributes::DirSeparator +
-																						 Attributes::Metadata + GlobalAttributes::SchemaExt, attribs));
+			buf.append(schparser.getCodeDefinition(GlobalAttributes::get().SchemasRootDir + GlobalAttributes::get().DirSeparator +
+																						 GlobalAttributes::get().XMLSchemaDir + GlobalAttributes::get().DirSeparator +
+																						 Attributes::Metadata + GlobalAttributes::get().SchemaExt, attribs));
 			output.write(buf.data(),buf.size());
 
 			emit s_objectLoaded(100, trUtf8("Metadata file successfully saved!"), enum_cast(ObjectType::BaseObject));
@@ -10478,12 +10478,12 @@ void DatabaseModel::saveObjectsMetadata(const QString &filename, unsigned option
 void DatabaseModel::loadObjectsMetadata(const QString &filename, unsigned options)
 {
 	QString elem_name, aux_elem, obj_name, ref_type,
-			dtd_file=GlobalAttributes::SchemasRootDir +
-							 GlobalAttributes::DirSeparator +
-							 GlobalAttributes::XMLSchemaDir +
-							 GlobalAttributes::DirSeparator +
-							 GlobalAttributes::ObjectDTDDir +
-							 GlobalAttributes::DirSeparator;
+			dtd_file=GlobalAttributes::get().SchemasRootDir +
+							 GlobalAttributes::get().DirSeparator +
+							 GlobalAttributes::get().XMLSchemaDir +
+							 GlobalAttributes::get().DirSeparator +
+							 GlobalAttributes::get().ObjectDTDDir +
+							 GlobalAttributes::get().DirSeparator;
 	attribs_map attribs, aux_attrib;
 	ObjectType obj_type;
 	BaseObject *object=nullptr, *new_object=nullptr;
@@ -10521,9 +10521,9 @@ void DatabaseModel::loadObjectsMetadata(const QString &filename, unsigned option
 
 		xmlparser.restartParser();
 
-		xmlparser.setDTDFile(dtd_file + GlobalAttributes::MetadataDTD +
-												 GlobalAttributes::ObjectDTDExt,
-												 GlobalAttributes::MetadataDTD);
+		xmlparser.setDTDFile(dtd_file + GlobalAttributes::get().MetadataDTD +
+												 GlobalAttributes::get().ObjectDTDExt,
+												 GlobalAttributes::get().MetadataDTD);
 
 		xmlparser.loadXMLFile(filename);
 
@@ -10951,12 +10951,12 @@ void DatabaseModel::getDataDictionary(attribs_map &datadict, bool browsable, boo
 	QString styles, id, index, items, buffer;
 	attribs_map attribs, aux_attribs;
 	QStringList index_list;
-	QString dict_files_root = GlobalAttributes::SchemasRootDir + GlobalAttributes::DirSeparator +
-														GlobalAttributes::DataDictSchemaDir + GlobalAttributes::DirSeparator,
-			dict_sch_file = dict_files_root + GlobalAttributes::DataDictSchemaDir + GlobalAttributes::SchemaExt,
-			style_sch_file = dict_files_root + Attributes::Styles + GlobalAttributes::SchemaExt,
-			item_sch_file = dict_files_root + Attributes::Item + GlobalAttributes::SchemaExt,
-			index_sch_file = dict_files_root + Attributes::Index + GlobalAttributes::SchemaExt;
+	QString dict_files_root = GlobalAttributes::get().SchemasRootDir + GlobalAttributes::get().DirSeparator +
+														GlobalAttributes::get().DataDictSchemaDir + GlobalAttributes::get().DirSeparator,
+			dict_sch_file = dict_files_root + GlobalAttributes::get().DataDictSchemaDir + GlobalAttributes::get().SchemaExt,
+			style_sch_file = dict_files_root + Attributes::Styles + GlobalAttributes::get().SchemaExt,
+			item_sch_file = dict_files_root + Attributes::Item + GlobalAttributes::get().SchemaExt,
+			index_sch_file = dict_files_root + Attributes::Index + GlobalAttributes::get().SchemaExt;
 
 	objects.assign(tables.begin(), tables.end());
 	objects.insert(objects.end(), foreign_tables.begin(), foreign_tables.end());
@@ -11079,7 +11079,7 @@ void DatabaseModel::saveDataDictionary(const QString &path, bool browsable, bool
 		for(auto &itr : datadict)
 		{
 			if(splitted)
-				output.setFileName(path + GlobalAttributes::DirSeparator + itr.first);
+				output.setFileName(path + GlobalAttributes::get().DirSeparator + itr.first);
 
 			output.open(QFile::WriteOnly);
 

--- a/libpgmodeler/src/physicaltable.cpp
+++ b/libpgmodeler/src/physicaltable.cpp
@@ -366,10 +366,10 @@ void PhysicalTable::addObject(BaseObject *obj, int obj_idx)
 #warning "DEMO VERSION: table children objects creation limit."
 		vector<TableObject *> *obj_list=(obj_type!=ObjectType::Table ? getObjectList(obj_type) : nullptr);
 
-		if((obj_list && obj_list->size() >= GlobalAttributes::MaxObjectCount) ||
-				(obj_type==ObjectType::Table && ancestor_tables.size() >= GlobalAttributes::MaxObjectCount))
+		if((obj_list && obj_list->size() >= GlobalAttributes::get().MaxObjectCount) ||
+				(obj_type==ObjectType::Table && ancestor_tables.size() >= GlobalAttributes::get().MaxObjectCount))
 			throw Exception(trUtf8("In demonstration version tables can have only `%1' instances of each child object type or ancestor tables! You've reach this limit for the type: `%2'")
-							.arg(GlobalAttributes::MaxObjectCount)
+							.arg(GlobalAttributes::get().MaxObjectCount)
 							.arg(BaseObject::getTypeName(obj_type)),
 							ErrorCode::Custom,__PRETTY_FUNCTION__,__FILE__,__LINE__);
 
@@ -1723,12 +1723,12 @@ QString PhysicalTable::getDataDictionary(bool splitted, attribs_map extra_attrib
 	Constraint *constr = nullptr;
 	attribs_map attribs, aux_attrs;
 	QStringList tab_names, col_names;
-	QString dict_files_root = GlobalAttributes::SchemasRootDir + GlobalAttributes::DirSeparator +
-														GlobalAttributes::DataDictSchemaDir + GlobalAttributes::DirSeparator,
-			tab_dict_file = dict_files_root + Attributes::Table + GlobalAttributes::SchemaExt,
-			col_dict_file = dict_files_root + Attributes::Column + GlobalAttributes::SchemaExt,
-			constr_dict_file = dict_files_root + Attributes::Constraint + GlobalAttributes::SchemaExt,
-			link_dict_file = dict_files_root + Attributes::Link + GlobalAttributes::SchemaExt,
+	QString dict_files_root = GlobalAttributes::get().SchemasRootDir + GlobalAttributes::get().DirSeparator +
+														GlobalAttributes::get().DataDictSchemaDir + GlobalAttributes::get().DirSeparator,
+			tab_dict_file = dict_files_root + Attributes::Table + GlobalAttributes::get().SchemaExt,
+			col_dict_file = dict_files_root + Attributes::Column + GlobalAttributes::get().SchemaExt,
+			constr_dict_file = dict_files_root + Attributes::Constraint + GlobalAttributes::get().SchemaExt,
+			link_dict_file = dict_files_root + Attributes::Link + GlobalAttributes::get().SchemaExt,
 			check_mark = QString("&#10003;");
 
 	attribs.insert(extra_attribs.begin(), extra_attribs.end());

--- a/libpgmodeler/src/view.cpp
+++ b/libpgmodeler/src/view.cpp
@@ -1110,11 +1110,11 @@ QString View::getDataDictionary(bool splitted, attribs_map extra_attribs)
 {
 	attribs_map attribs, aux_attrs;
 	QStringList tab_names, col_names;
-	QString dict_files_root = GlobalAttributes::SchemasRootDir + GlobalAttributes::DirSeparator +
-														GlobalAttributes::DataDictSchemaDir + GlobalAttributes::DirSeparator,
-			view_dict_file = dict_files_root + getSchemaName() + GlobalAttributes::SchemaExt,
-			col_dict_file = dict_files_root + Attributes::Column + GlobalAttributes::SchemaExt,
-			link_dict_file = dict_files_root + Attributes::Link + GlobalAttributes::SchemaExt;
+	QString dict_files_root = GlobalAttributes::get().SchemasRootDir + GlobalAttributes::get().DirSeparator +
+														GlobalAttributes::get().DataDictSchemaDir + GlobalAttributes::get().DirSeparator,
+			view_dict_file = dict_files_root + getSchemaName() + GlobalAttributes::get().SchemaExt,
+			col_dict_file = dict_files_root + Attributes::Column + GlobalAttributes::get().SchemaExt,
+			link_dict_file = dict_files_root + Attributes::Link + GlobalAttributes::get().SchemaExt;
 
 	attribs.insert(extra_attribs.begin(), extra_attribs.end());
 	attribs[Attributes::Type] = getTypeName();

--- a/libpgmodeler_ui/src/aboutwidget.cpp
+++ b/libpgmodeler_ui/src/aboutwidget.cpp
@@ -36,8 +36,8 @@ AboutWidget::AboutWidget(QWidget *parent) : QWidget(parent)
 	PgModelerUiNs::configureWidgetFont(build_lbl, PgModelerUiNs::BigFontFactor);
 	PgModelerUiNs::configureWidgetFont(build_num_lbl, PgModelerUiNs::BigFontFactor);
 
-	pgmodeler_ver_lbl->setText(QString("v%1 ").arg(GlobalAttributes::PgModelerVersion));
-	build_num_lbl->setText(QString("%1 Qt %2").arg(GlobalAttributes::PgModelerBuildNumber).arg(QT_VERSION_STR));
+	pgmodeler_ver_lbl->setText(QString("v%1 ").arg(GlobalAttributes::get().PgModelerVersion));
+	build_num_lbl->setText(QString("%1 Qt %2").arg(GlobalAttributes::get().PgModelerBuildNumber).arg(QT_VERSION_STR));
 
 	connect(hide_tb, &QToolButton::clicked, this,
 			[&](){

--- a/libpgmodeler_ui/src/aggregatewidget.cpp
+++ b/libpgmodeler_ui/src/aggregatewidget.cpp
@@ -28,7 +28,7 @@ AggregateWidget::AggregateWidget(QWidget *parent): BaseObjectWidget(parent, Obje
 		QFrame *frame=nullptr;
 
 		initial_cond_hl=new SyntaxHighlighter(initial_cond_txt);
-		initial_cond_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		initial_cond_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 		final_func_sel=new ObjectSelectorWidget(ObjectType::Function, true, this);
 		transition_func_sel=new ObjectSelectorWidget(ObjectType::Function, true, this);

--- a/libpgmodeler_ui/src/appearanceconfigwidget.cpp
+++ b/libpgmodeler_ui/src/appearanceconfigwidget.cpp
@@ -167,9 +167,9 @@ void AppearanceConfigWidget::loadExampleModel(void)
 
 		if(model->getObjectCount()==0)
 		{
-			model->loadModel(GlobalAttributes::TmplConfigurationDir +
-							 GlobalAttributes::DirSeparator +
-							 GlobalAttributes::ExampleModel);
+			model->loadModel(GlobalAttributes::get().TmplConfigurationDir +
+							 GlobalAttributes::get().DirSeparator +
+							 GlobalAttributes::get().ExampleModel);
 
 			count=model->getObjectCount(ObjectType::Table);
 			for(i=0; i < count; i++)
@@ -324,8 +324,8 @@ void AppearanceConfigWidget::saveConfiguration(void)
 			}
 		}
 
-		config_params[GlobalAttributes::ObjectsStyleConf]=attribs;
-		BaseConfigWidget::saveConfiguration(GlobalAttributes::ObjectsStyleConf, config_params);
+		config_params[GlobalAttributes::get().ObjectsStyleConf]=attribs;
+		BaseConfigWidget::saveConfiguration(GlobalAttributes::get().ObjectsStyleConf, config_params);
 	}
 	catch(Exception &e)
 	{
@@ -435,7 +435,7 @@ void AppearanceConfigWidget::restoreDefaults(void)
 {
 	try
 	{
-		BaseConfigWidget::restoreDefaults(GlobalAttributes::ObjectsStyleConf, false);
+		BaseConfigWidget::restoreDefaults(GlobalAttributes::get().ObjectsStyleConf, false);
 		this->loadConfiguration();
 		setConfigurationChanged(true);
 	}

--- a/libpgmodeler_ui/src/baseconfigwidget.cpp
+++ b/libpgmodeler_ui/src/baseconfigwidget.cpp
@@ -50,18 +50,18 @@ void BaseConfigWidget::saveConfiguration(const QString &conf_id, map<QString, at
 	QByteArray buf;
 
 	//Configures the schema filename for the configuration
-	QString	sch_filename=GlobalAttributes::TmplConfigurationDir +
-						 GlobalAttributes::DirSeparator +
-						 GlobalAttributes::SchemasDir +
-						 GlobalAttributes::DirSeparator +
+	QString	sch_filename=GlobalAttributes::get().TmplConfigurationDir +
+						 GlobalAttributes::get().DirSeparator +
+						 GlobalAttributes::get().SchemasDir +
+						 GlobalAttributes::get().DirSeparator +
 						 conf_id +
-						 GlobalAttributes::SchemaExt,
+						 GlobalAttributes::get().SchemaExt,
 
 			//Cofnigures the filename for the configuration file
-			cfg_filename=GlobalAttributes::ConfigurationsDir +
-						 GlobalAttributes::DirSeparator +
+			cfg_filename=GlobalAttributes::get().ConfigurationsDir +
+						 GlobalAttributes::get().DirSeparator +
 						 conf_id +
-						 GlobalAttributes::ConfigurationExt;
+						 GlobalAttributes::get().ConfigurationExt;
 	QFile output(cfg_filename);
 	attribs_map attribs;
 	map<QString, attribs_map >::iterator itr, itr_end;
@@ -104,18 +104,18 @@ void BaseConfigWidget::restoreDefaults(const QString &conf_id, bool silent)
 	QString current_file, default_file;
 
 	//Build the path to the current configuration (conf/[conf_id].conf
-	current_file=GlobalAttributes::ConfigurationsDir +
-				 GlobalAttributes::DirSeparator +
+	current_file=GlobalAttributes::get().ConfigurationsDir +
+				 GlobalAttributes::get().DirSeparator +
 				 conf_id +
-				 GlobalAttributes::ConfigurationExt;
+				 GlobalAttributes::get().ConfigurationExt;
 
 	//Build the path to the default configuration file (conf/defaults/[conf_id].conf
-	default_file=GlobalAttributes::TmplConfigurationDir +
-				 GlobalAttributes::DirSeparator +
-				 GlobalAttributes::DefaultConfsDir+
-				 GlobalAttributes::DirSeparator +
+	default_file=GlobalAttributes::get().TmplConfigurationDir +
+				 GlobalAttributes::get().DirSeparator +
+				 GlobalAttributes::get().DefaultConfsDir+
+				 GlobalAttributes::get().DirSeparator +
 				 conf_id +
-				 GlobalAttributes::ConfigurationExt;
+				 GlobalAttributes::get().ConfigurationExt;
 
 	//Raises an error if the default file doesn't exists
 	if(!QFile::exists(default_file))
@@ -126,8 +126,8 @@ void BaseConfigWidget::restoreDefaults(const QString &conf_id, bool silent)
 		bool bkp_saved = false;
 		QFileInfo fi(current_file);
 		QDir dir;
-		QString bkp_dir = fi.absolutePath() + GlobalAttributes::DirSeparator + GlobalAttributes::ConfsBackupsDir,
-				bkp_filename = bkp_dir + GlobalAttributes::DirSeparator +
+		QString bkp_dir = fi.absolutePath() + GlobalAttributes::get().DirSeparator + GlobalAttributes::get().ConfsBackupsDir,
+				bkp_filename = bkp_dir + GlobalAttributes::get().DirSeparator +
 											 QString("%1.bkp_%2").arg(fi.fileName()).arg(QDateTime::currentDateTime().toString("yyyyMMd_hhmmss"));
 
 		dir.mkpath(bkp_dir);
@@ -148,19 +148,19 @@ void BaseConfigWidget::loadConfiguration(const QString &conf_id, map<QString, at
 
 	try
 	{
-		filename = GlobalAttributes::ConfigurationsDir +
-							 GlobalAttributes::DirSeparator +
+		filename = GlobalAttributes::get().ConfigurationsDir +
+							 GlobalAttributes::get().DirSeparator +
 							 conf_id +
-							 GlobalAttributes::ConfigurationExt;
+							 GlobalAttributes::get().ConfigurationExt;
 
 		config_params.clear();
 		xmlparser.restartParser();
-		xmlparser.setDTDFile(GlobalAttributes::TmplConfigurationDir +
-							 GlobalAttributes::DirSeparator +
-							 GlobalAttributes::ObjectDTDDir +
-							 GlobalAttributes::DirSeparator +
+		xmlparser.setDTDFile(GlobalAttributes::get().TmplConfigurationDir +
+							 GlobalAttributes::get().DirSeparator +
+							 GlobalAttributes::get().ObjectDTDDir +
+							 GlobalAttributes::get().DirSeparator +
 							 conf_id +
-							 GlobalAttributes::ObjectDTDExt,
+							 GlobalAttributes::get().ObjectDTDExt,
 							 conf_id);
 
 		xmlparser.loadXMLFile(filename);

--- a/libpgmodeler_ui/src/bugreportform.cpp
+++ b/libpgmodeler_ui/src/bugreportform.cpp
@@ -40,13 +40,13 @@ BugReportForm::BugReportForm(QWidget *parent, Qt::WindowFlags f) : QDialog(paren
 	connect(actions_txt, SIGNAL(textChanged()), this, SLOT(enableGeneration()));
 	connect(output_edt, SIGNAL(textChanged(QString)), this, SLOT(enableGeneration()));
 
-	output_edt->setText(QFileInfo(GlobalAttributes::TemporaryDir).absoluteFilePath());
+	output_edt->setText(QFileInfo(GlobalAttributes::get().TemporaryDir).absoluteFilePath());
 
 	//Installs a syntax highlighter on model_txt widget
 	hl_model_txt=new SyntaxHighlighter(model_txt);
-	hl_model_txt->loadConfiguration(GlobalAttributes::XMLHighlightConfPath);
+	hl_model_txt->loadConfiguration(GlobalAttributes::get().XMLHighlightConfPath);
 
-	QDir tmp_dir=QDir(GlobalAttributes::TemporaryDir, QString("*.dbm"), QDir::Name, QDir::Files | QDir::NoDotAndDotDot);
+	QDir tmp_dir=QDir(GlobalAttributes::get().TemporaryDir, QString("*.dbm"), QDir::Name, QDir::Files | QDir::NoDotAndDotDot);
 	tmp_dir.setSorting(QDir::Time);
 	QStringList list=tmp_dir.entryList();
 
@@ -55,8 +55,8 @@ BugReportForm::BugReportForm(QWidget *parent, Qt::WindowFlags f) : QDialog(paren
 		QFile input;
 
 		//Opens the last modified model file showing it on the proper widget
-		input.setFileName(GlobalAttributes::TemporaryDir +
-						  GlobalAttributes::DirSeparator + list[0]);
+		input.setFileName(GlobalAttributes::get().TemporaryDir +
+						  GlobalAttributes::get().DirSeparator + list[0]);
 
 		input.open(QFile::ReadOnly);
 		model_txt->setPlainText(QString(input.readAll()));
@@ -79,7 +79,7 @@ QByteArray BugReportForm::generateReportBuffer(void)
 }
 
 void BugReportForm::generateReport(void)
-{ 
+{
 	generateReport(generateReportBuffer());
 	this->accept();
 }
@@ -94,8 +94,8 @@ void BugReportForm::generateReport(const QByteArray &buf)
 	Messagebox msgbox;
 	QFile output;
 	QString filename=QFileInfo(QString(output_edt->text() +
-									   GlobalAttributes::DirSeparator +
-									   GlobalAttributes::BugReportFile)
+									   GlobalAttributes::get().DirSeparator +
+									   GlobalAttributes::get().BugReportFile)
 							   .arg(QDateTime::currentDateTime().toString(QString("_yyyyMMdd_hhmm")))).absoluteFilePath();
 
 	//Opens the file for writting
@@ -116,7 +116,7 @@ void BugReportForm::generateReport(const QByteArray &buf)
 		output.close();
 
 		msgbox.show(trUtf8("Bug report successfuly generated! Please, send the file <strong>%1</strong> to <em>%2</em> in order be analyzed. Thank you for the collaboration!")
-								.arg(QDir::toNativeSeparators(filename)).arg(GlobalAttributes::BugReportEmail),
+								.arg(QDir::toNativeSeparators(filename)).arg(GlobalAttributes::get().BugReportEmail),
 					Messagebox::InfoIcon);
 	}
 }

--- a/libpgmodeler_ui/src/columnwidget.cpp
+++ b/libpgmodeler_ui/src/columnwidget.cpp
@@ -39,7 +39,7 @@ ColumnWidget::ColumnWidget(QWidget *parent): BaseObjectWidget(parent, ObjectType
 
 		hl_default_value=nullptr;
 		hl_default_value=new SyntaxHighlighter(def_value_txt, true);
-		hl_default_value->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		hl_default_value->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 		sequence_sel=new ObjectSelectorWidget(ObjectType::Sequence, true, this);
 		sequence_sel->setEnabled(false);

--- a/libpgmodeler_ui/src/connectionsconfigwidget.cpp
+++ b/libpgmodeler_ui/src/connectionsconfigwidget.cpp
@@ -112,7 +112,7 @@ void ConnectionsConfigWidget::loadConfiguration(void)
 
 		destroyConnections();
 		key_attribs.push_back(Attributes::Alias);
-		BaseConfigWidget::loadConfiguration(GlobalAttributes::ConnectionsConf, config_params, key_attribs);
+		BaseConfigWidget::loadConfiguration(GlobalAttributes::get().ConnectionsConf, config_params, key_attribs);
 
 		itr=config_params.begin();
 		itr_end=config_params.end();
@@ -438,7 +438,7 @@ void ConnectionsConfigWidget::restoreDefaults(void)
 	try
 	{
 		//Restore the default connection config file
-		BaseConfigWidget::restoreDefaults(GlobalAttributes::ConnectionsConf, false);
+		BaseConfigWidget::restoreDefaults(GlobalAttributes::get().ConnectionsConf, false);
 
 		//Remove all connections
 		while(connections_cmb->count() > 0)
@@ -476,12 +476,12 @@ void ConnectionsConfigWidget::saveConfiguration(void)
 				handleConnection();
 		}
 
-		config_params[GlobalAttributes::ConnectionsConf].clear();
+		config_params[GlobalAttributes::get().ConnectionsConf].clear();
 
 		/* Workaround: When there is no connection, to prevent saving an empty file, is necessary to
 		 fill the attribute CONNECTIONS with white spaces */
 		if(connections.empty())
-			config_params[GlobalAttributes::ConnectionsConf][Attributes::Connections]=QString("  ");
+			config_params[GlobalAttributes::get().ConnectionsConf][Attributes::Connections]=QString("  ");
 		else
 		{
 			for(Connection *conn : connections)
@@ -501,13 +501,13 @@ void ConnectionsConfigWidget::saveConfiguration(void)
 				attribs[DefaultFor.arg(Attributes::Validation)]=(conn->isDefaultForOperation(Connection::OpValidation) ? Attributes::True : QString());
 
 				schparser.ignoreUnkownAttributes(true);
-				config_params[GlobalAttributes::ConnectionsConf][Attributes::Connections]+=
-						schparser.getCodeDefinition(GlobalAttributes::TmplConfigurationDir +
-													GlobalAttributes::DirSeparator +
-													GlobalAttributes::SchemasDir +
-													GlobalAttributes::DirSeparator +
-													GlobalAttributes::ConnectionsConf +
-													GlobalAttributes::SchemaExt,
+				config_params[GlobalAttributes::get().ConnectionsConf][Attributes::Connections]+=
+						schparser.getCodeDefinition(GlobalAttributes::get().TmplConfigurationDir +
+													GlobalAttributes::get().DirSeparator +
+													GlobalAttributes::get().SchemasDir +
+													GlobalAttributes::get().DirSeparator +
+													GlobalAttributes::get().ConnectionsConf +
+													GlobalAttributes::get().SchemaExt,
 													attribs);
 
 				schparser.ignoreUnkownAttributes(false);
@@ -515,7 +515,7 @@ void ConnectionsConfigWidget::saveConfiguration(void)
 		}
 
 		schparser.ignoreUnkownAttributes(true);
-		BaseConfigWidget::saveConfiguration(GlobalAttributes::ConnectionsConf, config_params);
+		BaseConfigWidget::saveConfiguration(GlobalAttributes::get().ConnectionsConf, config_params);
 		schparser.ignoreUnkownAttributes(false);
 	}
 	catch(Exception &e)

--- a/libpgmodeler_ui/src/constraintwidget.cpp
+++ b/libpgmodeler_ui/src/constraintwidget.cpp
@@ -36,7 +36,7 @@ ConstraintWidget::ConstraintWidget(QWidget *parent): BaseObjectWidget(parent, Ob
 		excl_elems_grp->setLayout(grid);
 
 		expression_hl=new SyntaxHighlighter(expression_txt, false, true);
-		expression_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		expression_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 		columns_tab=new ObjectsTableWidget(ObjectsTableWidget::AllButtons ^
 										  (ObjectsTableWidget::EditButton |

--- a/libpgmodeler_ui/src/customsqlwidget.cpp
+++ b/libpgmodeler_ui/src/customsqlwidget.cpp
@@ -32,11 +32,11 @@ CustomSQLWidget::CustomSQLWidget(QWidget *parent) : BaseObjectWidget(parent)
 		prepend_sql_txt=PgModelerUiNs::createNumberedTextEditor(prepend_sql_wgt, true);
 
 		append_sql_hl=new SyntaxHighlighter(append_sql_txt);
-		append_sql_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		append_sql_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 		append_sql_cp=new CodeCompletionWidget(append_sql_txt, true);
 
 		prepend_sql_hl=new SyntaxHighlighter(prepend_sql_txt);
-		prepend_sql_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		prepend_sql_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 		prepend_sql_cp=new CodeCompletionWidget(prepend_sql_txt, true);
 
 		name_edt->setReadOnly(true);

--- a/libpgmodeler_ui/src/databaseexplorerwidget.cpp
+++ b/libpgmodeler_ui/src/databaseexplorerwidget.cpp
@@ -440,7 +440,7 @@ void DatabaseExplorerWidget::formatOidAttribs(attribs_map &attribs, QStringList 
 }
 
 void DatabaseExplorerWidget::formatCastAttribs(attribs_map &attribs)
-{  
+{
 	formatBooleanAttribs(attribs, { Attributes::IoCast });
 
 	formatOidAttribs(attribs, { Attributes::DestType,
@@ -1368,9 +1368,9 @@ bool DatabaseExplorerWidget::truncateTable(const QString &sch_name, const QStrin
 			//Generate the truncate command
 			schparser.ignoreEmptyAttributes(true);
 			schparser.ignoreUnkownAttributes(true);
-			truc_cmd=schparser.getCodeDefinition(GlobalAttributes::SchemasRootDir + GlobalAttributes::DirSeparator +
-																					 GlobalAttributes::AlterSchemaDir + GlobalAttributes::DirSeparator +
-																					 Attributes::Truncate + GlobalAttributes::SchemaExt,
+			truc_cmd=schparser.getCodeDefinition(GlobalAttributes::get().SchemasRootDir + GlobalAttributes::get().DirSeparator +
+																					 GlobalAttributes::get().AlterSchemaDir + GlobalAttributes::get().DirSeparator +
+																					 Attributes::Truncate + GlobalAttributes::get().SchemaExt,
 																					 attribs);
 
 			//Executes the truncate cmd
@@ -1767,9 +1767,9 @@ void DatabaseExplorerWidget::finishObjectRename(void)
 			//Generate the drop command
 			schparser.ignoreEmptyAttributes(true);
 			schparser.ignoreUnkownAttributes(true);
-			rename_cmd=schparser.getCodeDefinition(GlobalAttributes::SchemasRootDir + GlobalAttributes::DirSeparator +
-												   GlobalAttributes::AlterSchemaDir + GlobalAttributes::DirSeparator +
-													 Attributes::Rename + GlobalAttributes::SchemaExt,
+			rename_cmd=schparser.getCodeDefinition(GlobalAttributes::get().SchemasRootDir + GlobalAttributes::get().DirSeparator +
+												   GlobalAttributes::get().AlterSchemaDir + GlobalAttributes::get().DirSeparator +
+													 Attributes::Rename + GlobalAttributes::get().SchemaExt,
 												   attribs);
 
 			//Executes the rename cmd

--- a/libpgmodeler_ui/src/databaseimporthelper.cpp
+++ b/libpgmodeler_ui/src/databaseimporthelper.cpp
@@ -578,8 +578,8 @@ void DatabaseImportHelper::importDatabase(void)
 				QString log_name;
 
 				//Writing the erros to log file
-				log_name=GlobalAttributes::TemporaryDir +
-						 GlobalAttributes::DirSeparator +
+				log_name=GlobalAttributes::get().TemporaryDir +
+						 GlobalAttributes::get().DirSeparator +
 						 QString("%1_%2_%3.log").arg(dbmodel->getName())
 						 .arg(QString("import"))
 						 .arg(QDateTime::currentDateTime().toString(QString("yyyy-MM-dd_hhmmss")));
@@ -1772,7 +1772,7 @@ void DatabaseImportHelper::createView(attribs_map &attribs)
 		attribs[Attributes::Position]=schparser.getCodeDefinition(Attributes::Position, pos_attrib, SchemaParser::XmlDefinition);
 
 		ref=Reference(attribs[Attributes::Definition], QString());
-		ref.setDefinitionExpression(true);	
+		ref.setDefinitionExpression(true);
 
 		sch_name = getDependencyObject(attribs[Attributes::SchemaOid], ObjectType::Schema, true, auto_resolve_deps, false);
 		retrieveTableColumns(sch_name, attribs[Attributes::Name]);

--- a/libpgmodeler_ui/src/datamanipulationform.cpp
+++ b/libpgmodeler_ui/src/datamanipulationform.cpp
@@ -58,7 +58,7 @@ DataManipulationForm::DataManipulationForm(QWidget * parent, Qt::WindowFlags f):
 	PgModelerUiNs::configureWidgetFont(warning_lbl, PgModelerUiNs::MediumFontFactor);
 
 	filter_hl=new SyntaxHighlighter(filter_txt);
-	filter_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+	filter_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 	code_compl_wgt=new CodeCompletionWidget(filter_txt);
 	code_compl_wgt->configureCompletion(nullptr, filter_hl);
@@ -863,7 +863,7 @@ void DataManipulationForm::retrieveFKColumns(const QString &schema, const QStrin
 				submenu->addAction(trUtf8("(none)"))->setEnabled(false);
 
 			for(auto &fk : fks)
-			{				
+			{
 				aux_table = catalog.getObjectAttributes(ObjectType::Table, fk[Attributes::RefTable].toUInt());
 				aux_schema = catalog.getObjectAttributes(ObjectType::Schema, aux_table[Attributes::Schema].toUInt());
 				fk_name = QString("%1.%2.%3")

--- a/libpgmodeler_ui/src/domainwidget.cpp
+++ b/libpgmodeler_ui/src/domainwidget.cpp
@@ -27,7 +27,7 @@ DomainWidget::DomainWidget(QWidget *parent): BaseObjectWidget(parent, ObjectType
 
 		check_expr_hl=nullptr;
 		check_expr_hl=new SyntaxHighlighter(check_expr_txt, false, true);
-		check_expr_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		check_expr_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 		data_type=nullptr;
 		data_type=new PgSQLTypeWidget(this);

--- a/libpgmodeler_ui/src/donatewidget.cpp
+++ b/libpgmodeler_ui/src/donatewidget.cpp
@@ -40,7 +40,7 @@ DonateWidget::DonateWidget(QWidget *parent) : QWidget(parent)
 
 	connect(donate_tb, &QToolButton::clicked,
 			[&](){
-		QDesktopServices::openUrl(QUrl(GlobalAttributes::PgModelerDonateURL));
+		QDesktopServices::openUrl(QUrl(GlobalAttributes::get().PgModelerDonateURL));
 		this->close();
 		emit s_visibilityChanged(false);
 	});

--- a/libpgmodeler_ui/src/elementwidget.cpp
+++ b/libpgmodeler_ui/src/elementwidget.cpp
@@ -29,7 +29,7 @@ ElementWidget::ElementWidget(QWidget *parent) : QWidget(parent)
 
 		setupUi(this);
 		elem_expr_hl=new SyntaxHighlighter(elem_expr_txt, false, true);
-		elem_expr_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		elem_expr_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 		parent_obj=nullptr;
 		op_class_sel=new ObjectSelectorWidget(ObjectType::OpClass, true, this);

--- a/libpgmodeler_ui/src/functionwidget.cpp
+++ b/libpgmodeler_ui/src/functionwidget.cpp
@@ -366,15 +366,15 @@ void FunctionWidget::selectLanguage(void)
 	{
 		try
 		{
-			source_code_hl->loadConfiguration(GlobalAttributes::ConfigurationsDir +
-												GlobalAttributes::DirSeparator +
+			source_code_hl->loadConfiguration(GlobalAttributes::get().ConfigurationsDir +
+												GlobalAttributes::get().DirSeparator +
 											  language_cmb->currentText() +
-												GlobalAttributes::HighlightFileSuffix +
-												GlobalAttributes::ConfigurationExt);
+												GlobalAttributes::get().HighlightFileSuffix +
+												GlobalAttributes::get().ConfigurationExt);
 		}
 		catch(Exception &)
 		{
-			source_code_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+			source_code_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 		}
 
 		source_code_hl->rehighlight();

--- a/libpgmodeler_ui/src/generalconfigwidget.cpp
+++ b/libpgmodeler_ui/src/generalconfigwidget.cpp
@@ -236,7 +236,7 @@ GeneralConfigWidget::GeneralConfigWidget(QWidget * parent) : BaseConfigWidget(pa
 		connect(radio, SIGNAL(clicked()), this, SLOT(setConfigurationChanged()));
 	}
 
-	confs_dir_edt->setText(GlobalAttributes::ConfigurationsDir);
+	confs_dir_edt->setText(GlobalAttributes::get().ConfigurationsDir);
 
 	connect(open_dir_tb, &QToolButton::clicked, [&](){
 		QDesktopServices::openUrl(QUrl(QString("file://") + confs_dir_edt->text()));
@@ -252,8 +252,8 @@ GeneralConfigWidget::GeneralConfigWidget(QWidget * parent) : BaseConfigWidget(pa
 #endif
 
 	//Retrieving the available UI dictionaries
-	QStringList langs = QDir(GlobalAttributes::LanguagesDir +
-													 GlobalAttributes::DirSeparator,
+	QStringList langs = QDir(GlobalAttributes::get().LanguagesDir +
+													 GlobalAttributes::get().DirSeparator,
 													 QString("*.qm"), QDir::Name, QDir::AllEntries | QDir::NoDotAndDotDot).entryList();
 
 	langs.replaceInStrings(QString(".qm"), QString());
@@ -284,7 +284,7 @@ void GeneralConfigWidget::loadConfiguration(void)
 			wgt->blockSignals(true);
 
 		key_attribs.push_back(Attributes::Id);
-		BaseConfigWidget::loadConfiguration(GlobalAttributes::GeneralConf, config_params, key_attribs);
+		BaseConfigWidget::loadConfiguration(GlobalAttributes::get().GeneralConf, config_params, key_attribs);
 
 		grid_size_spb->setValue((config_params[Attributes::Configuration][Attributes::GridSize]).toUInt());
 		oplist_size_spb->setValue((config_params[Attributes::Configuration][Attributes::OpListSize]).toUInt());
@@ -489,20 +489,20 @@ void GeneralConfigWidget::saveConfiguration(void)
 		QString file_sch, root_dir, widget_sch;
 		int recent_mdl_idx = 0;
 
-		root_dir=GlobalAttributes::TmplConfigurationDir +
-				 GlobalAttributes::DirSeparator;
+		root_dir=GlobalAttributes::get().TmplConfigurationDir +
+				 GlobalAttributes::get().DirSeparator;
 
 		file_sch=root_dir +
-				 GlobalAttributes::SchemasDir +
-				 GlobalAttributes::DirSeparator +
+				 GlobalAttributes::get().SchemasDir +
+				 GlobalAttributes::get().DirSeparator +
 				 Attributes::File +
-				 GlobalAttributes::SchemaExt;
+				 GlobalAttributes::get().SchemaExt;
 
 		widget_sch=root_dir +
-				   GlobalAttributes::SchemasDir +
-				   GlobalAttributes::DirSeparator +
+				   GlobalAttributes::get().SchemasDir +
+				   GlobalAttributes::get().DirSeparator +
 				   Attributes::Widget +
-				   GlobalAttributes::SchemaExt;
+				   GlobalAttributes::get().SchemaExt;
 
 		config_params[Attributes::Configuration][Attributes::GridSize]=QString::number(grid_size_spb->value());
 		config_params[Attributes::Configuration][Attributes::OpListSize]=QString::number(oplist_size_spb->value());
@@ -631,7 +631,7 @@ void GeneralConfigWidget::saveConfiguration(void)
 			}
 		}
 
-		BaseConfigWidget::saveConfiguration(GlobalAttributes::GeneralConf, config_params);
+		BaseConfigWidget::saveConfiguration(GlobalAttributes::get().GeneralConf, config_params);
 	}
 	catch(Exception &e)
 	{
@@ -703,10 +703,10 @@ void GeneralConfigWidget::restoreDefaults(void)
 {
 	try
 	{
-		BaseConfigWidget::restoreDefaults(GlobalAttributes::GeneralConf, false);
-		BaseConfigWidget::restoreDefaults(GlobalAttributes::XMLHighlightConf, true);
-		BaseConfigWidget::restoreDefaults(GlobalAttributes::SQLHighlightConf, true);
-		BaseConfigWidget::restoreDefaults(GlobalAttributes::UiStyleConf, true);
+		BaseConfigWidget::restoreDefaults(GlobalAttributes::get().GeneralConf, false);
+		BaseConfigWidget::restoreDefaults(GlobalAttributes::get().XMLHighlightConf, true);
+		BaseConfigWidget::restoreDefaults(GlobalAttributes::get().SQLHighlightConf, true);
+		BaseConfigWidget::restoreDefaults(GlobalAttributes::get().UiStyleConf, true);
 		this->loadConfiguration();
 		this->applyConfiguration();
 		setConfigurationChanged(true);

--- a/libpgmodeler_ui/src/genericsqlwidget.cpp
+++ b/libpgmodeler_ui/src/genericsqlwidget.cpp
@@ -40,7 +40,7 @@ GenericSQLWidget::GenericSQLWidget(QWidget *parent): BaseObjectWidget(parent, Ob
 
 	definition_txt = PgModelerUiNs::createNumberedTextEditor(attribs_tbw->widget(0), true);
 	definition_hl = new SyntaxHighlighter(definition_txt);
-	definition_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+	definition_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 	definition_cp=new CodeCompletionWidget(definition_txt, true);
 
 	comment_edt->setVisible(false);
@@ -49,7 +49,7 @@ GenericSQLWidget::GenericSQLWidget(QWidget *parent): BaseObjectWidget(parent, Ob
 	preview_txt = PgModelerUiNs::createNumberedTextEditor(attribs_tbw->widget(2), false);
 	preview_txt->setReadOnly(true);
 	preview_hl = new SyntaxHighlighter(preview_txt);
-	preview_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+	preview_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 	attribs_tbw->widget(0)->layout()->setContentsMargins(4,4,4,4);
 	attribs_tbw->widget(0)->layout()->addWidget(definition_txt);

--- a/libpgmodeler_ui/src/indexwidget.cpp
+++ b/libpgmodeler_ui/src/indexwidget.cpp
@@ -31,7 +31,7 @@ IndexWidget::IndexWidget(QWidget *parent): BaseObjectWidget(parent, ObjectType::
 		Ui_IndexWidget::setupUi(this);
 
 		predicate_hl=new SyntaxHighlighter(predicate_txt, false, true);
-		predicate_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		predicate_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 		elements_tab = new ElementsTableWidget(this);
 

--- a/libpgmodeler_ui/src/mainwindow.cpp
+++ b/libpgmodeler_ui/src/mainwindow.cpp
@@ -253,7 +253,7 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags) : QMainWindow(par
 
 	connect(action_compact_view, SIGNAL(toggled(bool)), this, SLOT(toggleCompactView()));
 
-	window_title=this->windowTitle() + QString(" ") + GlobalAttributes::PgModelerVersion;
+	window_title=this->windowTitle() + QString(" ") + GlobalAttributes::get().PgModelerVersion;
 
 #ifdef DEMO_VERSION
 	window_title+=trUtf8(" (Demo)");
@@ -611,7 +611,7 @@ void MainWindow::fixModel(const QString &filename)
 	{
 		QFileInfo fi(filename);
 		model_fix_form.input_file_edt->setText(fi.absoluteFilePath());
-		model_fix_form.output_file_edt->setText(fi.absolutePath() + GlobalAttributes::DirSeparator + fi.baseName() + QString("_fixed.") + fi.suffix());
+		model_fix_form.output_file_edt->setText(fi.absolutePath() + GlobalAttributes::get().DirSeparator + fi.baseName() + QString("_fixed.") + fi.suffix());
 	}
 
 	PgModelerUiNs::resizeDialog(&model_fix_form);
@@ -1667,7 +1667,7 @@ void MainWindow::loadModels(const QStringList &list)
 			recent_models.push_front(list[i]);
 		}
 
-		updateRecentModelsMenu();		
+		updateRecentModelsMenu();
 		qApp->restoreOverrideCursor();
 	}
 	catch(Exception &e)
@@ -1773,7 +1773,7 @@ void MainWindow::showOverview(bool show)
 
 void MainWindow::openSupport(void)
 {
-	QDesktopServices::openUrl(QUrl(GlobalAttributes::PgModelerSupport));
+	QDesktopServices::openUrl(QUrl(GlobalAttributes::get().PgModelerSupport));
 }
 
 void MainWindow::toggleUpdateNotifier(bool show)
@@ -1834,7 +1834,7 @@ void MainWindow::setFloatingWidgetPos(QWidget *widget, QAction *act, QToolBar *t
 
 void MainWindow::configureSamplesMenu(void)
 {
-	QDir dir(GlobalAttributes::SamplesDir);
+	QDir dir(GlobalAttributes::get().SamplesDir);
 	QStringList files=dir.entryList({QString("*.dbm")});
 	QAction *act=nullptr;
 	QString path;
@@ -1842,7 +1842,7 @@ void MainWindow::configureSamplesMenu(void)
 	while(!files.isEmpty())
 	{
 		act=sample_mdls_menu.addAction(files.front(),this,SLOT(loadModelFromAction(void)));
-		path=QFileInfo(GlobalAttributes::SamplesDir + GlobalAttributes::DirSeparator + files.front()).absoluteFilePath();
+		path=QFileInfo(GlobalAttributes::get().SamplesDir + GlobalAttributes::get().DirSeparator + files.front()).absoluteFilePath();
 		act->setToolTip(path);
 		act->setData(path);
 		files.pop_front();
@@ -1921,7 +1921,7 @@ void MainWindow::showDemoVersionWarning(void)
 				 trUtf8("You're running a demonstration version! Note that you'll be able to create only <strong>%1</strong> instances \
 						of each type of object and some key features will be disabled or limited!<br/><br/>You can purchase a full binary copy or get the source code at <a href='https://pgmodeler.io'>https://pgmodeler.io</a>.\
 						<strong>NOTE:</strong> pgModeler is an open source software, but purchasing binary copies or providing some donations will support the project and keep the development alive and at full speed!<br/><br/>\
-						<strong>HINT:</strong> in order to test all features it's recommended to use the <strong>demo.dbm</strong> model located in </strong>Sample models</strong> at <strong>Welcome</strong> view.<br/><br/><br/><br/>").arg(GlobalAttributes::MaxObjectCount),
+						<strong>HINT:</strong> in order to test all features it's recommended to use the <strong>demo.dbm</strong> model located in </strong>Sample models</strong> at <strong>Welcome</strong> view.<br/><br/><br/><br/>").arg(GlobalAttributes::get().MaxObjectCount),
 						Messagebox::AlertIcon, Messagebox::OkButton);
 #endif
 }

--- a/libpgmodeler_ui/src/metadatahandlingform.cpp
+++ b/libpgmodeler_ui/src/metadatahandlingform.cpp
@@ -190,8 +190,8 @@ void MetadataHandlingForm::handleObjectsMetada(void)
 			else
 			{
 				//Configuring the temporary metadata file
-				tmp_file.setFileTemplate(GlobalAttributes::TemporaryDir +
-																 GlobalAttributes::DirSeparator +
+				tmp_file.setFileTemplate(GlobalAttributes::get().TemporaryDir +
+																 GlobalAttributes::get().DirSeparator +
 																 QString("%1_metadata_XXXXXX.%2").arg(extract_model->getName()).arg(QString("omf")));
 
 				tmp_file.open();

--- a/libpgmodeler_ui/src/modeldatabasediffform.cpp
+++ b/libpgmodeler_ui/src/modeldatabasediffform.cpp
@@ -105,7 +105,7 @@ ModelDatabaseDiffForm::ModelDatabaseDiffForm(QWidget *parent, Qt::WindowFlags fl
 		ignore_error_codes_ht->setText(ignore_error_codes_chk->statusTip());
 
 		sqlcode_hl=new SyntaxHighlighter(sqlcode_txt);
-		sqlcode_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		sqlcode_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 		pgsql_ver_cmb->addItems(PgSqlVersions::AllVersions);
 		PgModelerUiNs::configureWidgetFont(message_lbl, PgModelerUiNs::MediumFontFactor);
@@ -689,8 +689,8 @@ void ModelDatabaseDiffForm::loadDiffInSQLTool(void)
 			filename = file_edt->text();
 	else
 	{
-			tmp_sql_file.setFileTemplate(GlobalAttributes::TemporaryDir +
-																	 GlobalAttributes::DirSeparator +
+			tmp_sql_file.setFileTemplate(GlobalAttributes::get().TemporaryDir +
+																	 GlobalAttributes::get().DirSeparator +
 																	 QString("diff_%1_XXXXXX.sql").arg(database));
 
 			tmp_sql_file.open();
@@ -1025,7 +1025,7 @@ void ModelDatabaseDiffForm::loadConfiguration(void)
 {
 	try
 	{
-		BaseConfigWidget::loadConfiguration(GlobalAttributes::DiffPresetsConf, config_params, { Attributes::Name });
+		BaseConfigWidget::loadConfiguration(GlobalAttributes::get().DiffPresetsConf, config_params, { Attributes::Name });
 		applyConfiguration();
 	}
 	catch(Exception &e)
@@ -1047,14 +1047,14 @@ void ModelDatabaseDiffForm::saveConfiguration(void)
 		QString preset_sch, root_dir;
 		QString presets;
 
-		root_dir=GlobalAttributes::TmplConfigurationDir +
-				 GlobalAttributes::DirSeparator;
+		root_dir=GlobalAttributes::get().TmplConfigurationDir +
+				 GlobalAttributes::get().DirSeparator;
 
 		preset_sch=root_dir +
-				 GlobalAttributes::SchemasDir +
-				 GlobalAttributes::DirSeparator +
+				 GlobalAttributes::get().SchemasDir +
+				 GlobalAttributes::get().DirSeparator +
 				 Attributes::Preset +
-				 GlobalAttributes::SchemaExt;
+				 GlobalAttributes::get().SchemaExt;
 
 		for(auto &conf : config_params)
 		{
@@ -1065,8 +1065,8 @@ void ModelDatabaseDiffForm::saveConfiguration(void)
 			schparser.ignoreEmptyAttributes(false);
 		}
 
-		config_params[GlobalAttributes::DiffPresetsConf][Attributes::Preset] = presets;
-		BaseConfigWidget::saveConfiguration(GlobalAttributes::DiffPresetsConf, config_params);
+		config_params[GlobalAttributes::get().DiffPresetsConf][Attributes::Preset] = presets;
+		BaseConfigWidget::saveConfiguration(GlobalAttributes::get().DiffPresetsConf, config_params);
 	}
 	catch(Exception &e)
 	{
@@ -1097,8 +1097,8 @@ void ModelDatabaseDiffForm::restoreDefaults(void)
 
 		if(msg_box.result()==QDialog::Accepted)
 		{
-			BaseConfigWidget::restoreDefaults(GlobalAttributes::DiffPresetsConf, false);
-			BaseConfigWidget::loadConfiguration(GlobalAttributes::DiffPresetsConf, config_params, { Attributes::Name });
+			BaseConfigWidget::restoreDefaults(GlobalAttributes::get().DiffPresetsConf, false);
+			BaseConfigWidget::loadConfiguration(GlobalAttributes::get().DiffPresetsConf, config_params, { Attributes::Name });
 			applyConfiguration();
 		}
 	}

--- a/libpgmodeler_ui/src/modelexporthelper.cpp
+++ b/libpgmodeler_ui/src/modelexporthelper.cpp
@@ -148,7 +148,7 @@ void ModelExportHelper::exportToPNG(ObjectsScene *scene, const QString &filename
 			pages=scene->getPagesForPrinting(page_sz, margins.size(), h_cnt, v_cnt);
 
 			//Configures the template filename for pages pixmaps
-			tmpl_filename=fi.absolutePath() + GlobalAttributes::DirSeparator + fi.baseName() + QString("_p%1.") + fi.completeSuffix();
+			tmpl_filename=fi.absolutePath() + GlobalAttributes::get().DirSeparator + fi.baseName() + QString("_p%1.") + fi.completeSuffix();
 		}
 		else
 		{

--- a/libpgmodeler_ui/src/modelfixform.cpp
+++ b/libpgmodeler_ui/src/modelfixform.cpp
@@ -72,7 +72,7 @@ void ModelFixForm::hideEvent(QHideEvent *)
 
 int ModelFixForm::exec(void)
 {
-	QFileInfo fi(GlobalAttributes::PgModelerCLIPath);
+	QFileInfo fi(GlobalAttributes::get().PgModelerCLIPath);
 
 	//Show an warning if the cli command doesn't exists
 	if(!fi.exists())
@@ -85,7 +85,7 @@ int ModelFixForm::exec(void)
 		sel_cli_exe_tb->setVisible(true);
 	}
 	else
-		pgmodeler_cli_edt->setText(GlobalAttributes::PgModelerCLIPath);
+		pgmodeler_cli_edt->setText(GlobalAttributes::get().PgModelerCLIPath);
 
 	return(QDialog::exec());
 }

--- a/libpgmodeler_ui/src/modelrestorationform.cpp
+++ b/libpgmodeler_ui/src/modelrestorationform.cpp
@@ -35,7 +35,7 @@ ModelRestorationForm::ModelRestorationForm(QWidget *parent, Qt::WindowFlags f) :
 QStringList ModelRestorationForm::getTemporaryModels(void)
 {
 	//Returns if there is some .dbm file on the tmp dir
-	return(QDir(GlobalAttributes::TemporaryDir, QString("*.dbm"), QDir::Name, QDir::Files | QDir::NoDotAndDotDot).entryList());
+	return(QDir(GlobalAttributes::get().TemporaryDir, QString("*.dbm"), QDir::Name, QDir::Files | QDir::NoDotAndDotDot).entryList());
 }
 
 int ModelRestorationForm::exec(void)
@@ -50,8 +50,8 @@ int ModelRestorationForm::exec(void)
 
 	while(!file_list.isEmpty())
 	{
-		info.setFile(GlobalAttributes::TemporaryDir, file_list.front());
-		filename=GlobalAttributes::TemporaryDir + GlobalAttributes::DirSeparator + file_list.front();
+		info.setFile(GlobalAttributes::get().TemporaryDir, file_list.front());
+		filename=GlobalAttributes::get().TemporaryDir + GlobalAttributes::get().DirSeparator + file_list.front();
 
 		input.setFileName(filename);
 		input.open(QFile::ReadOnly);
@@ -100,11 +100,11 @@ bool ModelRestorationForm::hasTemporaryModels(void)
 void ModelRestorationForm::removeTemporaryFiles(void)
 {
 	QDir tmp_file;
-	QStringList tmp_files = QDir(GlobalAttributes::TemporaryDir, QString("*.dbm;*.dbk;*.omf;*.sql;*.log"),
+	QStringList tmp_files = QDir(GlobalAttributes::get().TemporaryDir, QString("*.dbm;*.dbk;*.omf;*.sql;*.log"),
 															 QDir::Name, QDir::Files | QDir::NoDotAndDotDot).entryList();
 
 	for(auto &file : tmp_files)
-		tmp_file.remove(GlobalAttributes::TemporaryDir + GlobalAttributes::DirSeparator + file);
+		tmp_file.remove(GlobalAttributes::get().TemporaryDir + GlobalAttributes::get().DirSeparator + file);
 }
 
 void ModelRestorationForm::removeTemporaryModels(void)
@@ -113,14 +113,14 @@ void ModelRestorationForm::removeTemporaryModels(void)
 	QDir tmp_file;
 
 	for(auto &file : file_list)
-		tmp_file.remove(GlobalAttributes::TemporaryDir + GlobalAttributes::DirSeparator + file);
+		tmp_file.remove(GlobalAttributes::get().TemporaryDir + GlobalAttributes::get().DirSeparator + file);
 }
 
 void ModelRestorationForm::removeTemporaryModel(const QString &tmp_model)
 {
 	QDir tmp_file;
 	QString file=QFileInfo(tmp_model).fileName();
-	tmp_file.remove(GlobalAttributes::TemporaryDir + GlobalAttributes::DirSeparator + file);
+	tmp_file.remove(GlobalAttributes::get().TemporaryDir + GlobalAttributes::get().DirSeparator + file);
 }
 
 void ModelRestorationForm::enableRestoration(void)

--- a/libpgmodeler_ui/src/modelsdiffhelper.cpp
+++ b/libpgmodeler_ui/src/modelsdiffhelper.cpp
@@ -73,7 +73,7 @@ void ModelsDiffHelper::setPgSQLVersion(const QString pgsql_ver)
 }
 
 void ModelsDiffHelper::resetDiffCounter(void)
-{  
+{
 	diffs_counter[ObjectsDiffInfo::AlterObject]=0;
 	diffs_counter[ObjectsDiffInfo::DropObject]=0;
 	diffs_counter[ObjectsDiffInfo::CreateObject]=0;
@@ -872,7 +872,7 @@ void ModelsDiffHelper::processDiffInfos(void)
 
 			//Attributes used on the diff schema file
 			attribs[Attributes::HasChanges]=Attributes::True;
-			attribs[Attributes::PgModelerVersion]=GlobalAttributes::PgModelerVersion;
+			attribs[Attributes::PgModelerVersion]=GlobalAttributes::get().PgModelerVersion;
 			attribs[Attributes::DbModel]=source_model->getName();
 			attribs[Attributes::Database]=imported_model->getName();
 			attribs[Attributes::Date]=QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss");
@@ -925,9 +925,9 @@ void ModelsDiffHelper::processDiffInfos(void)
 
 			//Generating the whole diff buffer
 			schparser.setPgSQLVersion(pgsql_version);
-			diff_def=schparser.getCodeDefinition(GlobalAttributes::SchemasRootDir + GlobalAttributes::DirSeparator +
-												 GlobalAttributes::AlterSchemaDir + GlobalAttributes::DirSeparator +
-												 Attributes::Diff + GlobalAttributes::SchemaExt, attribs);
+			diff_def=schparser.getCodeDefinition(GlobalAttributes::get().SchemasRootDir + GlobalAttributes::get().DirSeparator +
+												 GlobalAttributes::get().AlterSchemaDir + GlobalAttributes::get().DirSeparator +
+												 Attributes::Diff + GlobalAttributes::get().SchemaExt, attribs);
 		}
 
 		if(diff_def.isEmpty())

--- a/libpgmodeler_ui/src/modelwidget.cpp
+++ b/libpgmodeler_ui/src/modelwidget.cpp
@@ -100,7 +100,7 @@ ModelWidget::ModelWidget(QWidget *parent) : QWidget(parent)
 	QTemporaryFile tmp_file;
 
 	//Configuring the template mask which includes the full path to temporary dir
-	tmp_file.setFileTemplate(GlobalAttributes::TemporaryDir + GlobalAttributes::DirSeparator + QString("model_XXXXXX") + QString(".dbm"));
+	tmp_file.setFileTemplate(GlobalAttributes::get().TemporaryDir + GlobalAttributes::get().DirSeparator + QString("model_XXXXXX") + QString(".dbm"));
 	tmp_file.open();
 	tmp_filename=tmp_file.fileName();
 	tmp_file.close();
@@ -976,7 +976,7 @@ void ModelWidget::handleObjectsMovement(bool end_moviment)
 						reg_tables.push_back(tab->getUnderlyingObject());
 					}
 				}
-			}			
+			}
 		}
 	}
 	else
@@ -1636,8 +1636,8 @@ void ModelWidget::saveModel(const QString &filename)
 		{
 			// Generate a temporary backup file
 			tmpfile.setAutoRemove(false);
-			tmpfile.setFileTemplate(GlobalAttributes::TemporaryDir +
-															GlobalAttributes::DirSeparator +
+			tmpfile.setFileTemplate(GlobalAttributes::get().TemporaryDir +
+															GlobalAttributes::get().DirSeparator +
 															QString("%1_XXXXXX.dbk").arg(this->db_model->getName()));
 			tmpfile.open();
 			bkpfile = tmpfile.fileName();

--- a/libpgmodeler_ui/src/numberedtexteditor.cpp
+++ b/libpgmodeler_ui/src/numberedtexteditor.cpp
@@ -366,7 +366,7 @@ void NumberedTextEditor::editSource(void)
 	if(tmp_src_file.isEmpty())
 	{
 		QTemporaryFile tmp_file;
-		tmp_file.setFileTemplate(GlobalAttributes::TemporaryDir + GlobalAttributes::DirSeparator + QString("source_XXXXXX") + QString(".sql"));
+		tmp_file.setFileTemplate(GlobalAttributes::get().TemporaryDir + GlobalAttributes::get().DirSeparator + QString("source_XXXXXX") + QString(".sql"));
 		tmp_file.open();
 		tmp_src_file = tmp_file.fileName();
 		tmp_file.close();

--- a/libpgmodeler_ui/src/objectselectorwidget.cpp
+++ b/libpgmodeler_ui/src/objectselectorwidget.cpp
@@ -58,7 +58,7 @@ void ObjectSelectorWidget::configureSelector(bool install_highlighter)
 		if(install_highlighter)
 		{
 			obj_name_hl=new SyntaxHighlighter(obj_name_txt, true);
-			obj_name_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+			obj_name_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 		}
 		else
 		{

--- a/libpgmodeler_ui/src/permissionwidget.cpp
+++ b/libpgmodeler_ui/src/permissionwidget.cpp
@@ -34,7 +34,7 @@ PermissionWidget::PermissionWidget(QWidget *parent): BaseObjectWidget(parent, Ob
 	Ui_PermissionWidget::setupUi(this);
 
 	code_hl=new SyntaxHighlighter(code_txt);
-	code_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+	code_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 	object_selection_wgt=new ModelObjectsWidget(true);
 	permission=nullptr;
@@ -385,7 +385,7 @@ void PermissionWidget::editPermission(void)
 }
 
 void PermissionWidget::removePermission(int)
-{ 
+{
 	model->removePermission(permission);
 	cancelOperation();
 	permission=nullptr;

--- a/libpgmodeler_ui/src/pgsqltypewidget.cpp
+++ b/libpgmodeler_ui/src/pgsqltypewidget.cpp
@@ -35,7 +35,7 @@ PgSQLTypeWidget::PgSQLTypeWidget(QWidget *parent, const QString &label) : QWidge
 
 		format_hl=nullptr;
 		format_hl=new SyntaxHighlighter(format_txt, true);
-		format_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		format_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 		this->adjustSize();
 
 		IntervalType::getTypes(interval_lst);

--- a/libpgmodeler_ui/src/pluginsconfigwidget.cpp
+++ b/libpgmodeler_ui/src/pluginsconfigwidget.cpp
@@ -23,7 +23,7 @@ PluginsConfigWidget::PluginsConfigWidget(QWidget *parent) : BaseConfigWidget(par
 	setupUi(this);
 
 	QGridLayout *grid=new QGridLayout(loaded_plugins_gb);
-	QDir dir=QDir(GlobalAttributes::PluginsDir);
+	QDir dir=QDir(GlobalAttributes::get().PluginsDir);
 
 	root_dir_edt->setText(dir.absolutePath());
 
@@ -65,8 +65,8 @@ void PluginsConfigWidget::loadConfiguration(void)
 {
 	vector<Exception> errors;
 	QString lib, plugin_name,
-			dir_plugins=GlobalAttributes::PluginsDir +
-						GlobalAttributes::DirSeparator;
+			dir_plugins=GlobalAttributes::get().PluginsDir +
+						GlobalAttributes::get().DirSeparator;
 	QPluginLoader plugin_loader;
 	QStringList dir_list;
 	PgModelerPlugin *plugin=nullptr;
@@ -90,16 +90,16 @@ void PluginsConfigWidget::loadConfiguration(void)
 		 [PLUGINS ROOT DIR]/[PLUGIN NAME]/lib[PLUGIN NAME].[EXTENSION] */
 #ifdef Q_OS_WIN
 		lib=dir_plugins + plugin_name +
-            GlobalAttributes::DirSeparator  +
+            GlobalAttributes::get().DirSeparator  +
 			plugin_name + QString(".dll");
 #else
 #ifdef Q_OS_MAC
 		lib=dir_plugins + plugin_name +
-            GlobalAttributes::DirSeparator  +
+            GlobalAttributes::get().DirSeparator  +
 			QString("lib") + plugin_name + QString(".dylib");
 #else
 		lib=dir_plugins + plugin_name +
-			GlobalAttributes::DirSeparator  +
+			GlobalAttributes::get().DirSeparator  +
 			QString("lib") + plugin_name + QString(".so");
 #endif
 #endif
@@ -123,7 +123,7 @@ void PluginsConfigWidget::loadConfiguration(void)
 				plugin_action->setShortcut(plugin->getPluginShortcut());
 
 				icon.load(dir_plugins + plugin_name +
-									GlobalAttributes::DirSeparator  +
+									GlobalAttributes::get().DirSeparator  +
 									plugin_name + QString(".png"));
 
 				plugin_action->setIcon(icon);

--- a/libpgmodeler_ui/src/policywidget.cpp
+++ b/libpgmodeler_ui/src/policywidget.cpp
@@ -30,12 +30,12 @@ PolicyWidget::PolicyWidget(QWidget *parent): BaseObjectWidget(parent, ObjectType
 		using_edt = PgModelerUiNs::createNumberedTextEditor(using_wgt);
 		using_edt->setTabChangesFocus(true);
 		using_hl = new SyntaxHighlighter(using_edt);
-		using_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		using_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 		check_edt = PgModelerUiNs::createNumberedTextEditor(check_wgt);
 		check_edt->setTabChangesFocus(true);
 		check_hl = new SyntaxHighlighter(check_edt);
-		check_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		check_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 		roles_tab = new ObjectsTableWidget(ObjectsTableWidget::AllButtons ^
 																			 (ObjectsTableWidget::DuplicateButton |

--- a/libpgmodeler_ui/src/referencewidget.cpp
+++ b/libpgmodeler_ui/src/referencewidget.cpp
@@ -40,7 +40,7 @@ ReferenceWidget::ReferenceWidget(QWidget *parent) : QWidget(parent)
 
 	expression_txt=new NumberedTextEditor(this, true);
 	expression_hl=new SyntaxHighlighter(expression_txt, false, true);
-	expression_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+	expression_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 	ref_object_sel=new ObjectSelectorWidget({ ObjectType::Table, ObjectType::ForeignTable, ObjectType::Column }, true, this);
 	ref_object_sel->enableObjectCreation(false);

--- a/libpgmodeler_ui/src/relationshipconfigwidget.cpp
+++ b/libpgmodeler_ui/src/relationshipconfigwidget.cpp
@@ -39,10 +39,10 @@ RelationshipConfigWidget::RelationshipConfigWidget(QWidget * parent) : BaseConfi
 	for(int i=0; i < pattern_fields.size(); i++)
 	{
 		pattern_hl=new SyntaxHighlighter(pattern_fields[i], true);
-		pattern_hl->loadConfiguration(GlobalAttributes::ConfigurationsDir +
-									  GlobalAttributes::DirSeparator +
-									  GlobalAttributes::PatternHighlightConf +
-									  GlobalAttributes::ConfigurationExt);
+		pattern_hl->loadConfiguration(GlobalAttributes::get().ConfigurationsDir +
+									  GlobalAttributes::get().DirSeparator +
+									  GlobalAttributes::get().PatternHighlightConf +
+									  GlobalAttributes::get().ConfigurationExt);
 
 		connect(pattern_fields[i], SIGNAL(textChanged()), this, SLOT(updatePattern()));
 	}
@@ -96,7 +96,7 @@ void RelationshipConfigWidget::loadConfiguration(void)
 	{
 		int idx;
 		vector<QString> key_attribs={Attributes::Type};
-		BaseConfigWidget::loadConfiguration(GlobalAttributes::RelationshipsConf, config_params, key_attribs);
+		BaseConfigWidget::loadConfiguration(GlobalAttributes::get().RelationshipsConf, config_params, key_attribs);
 
 		fk_to_pk_rb->setChecked(config_params[Attributes::Connection][Attributes::Mode]==Attributes::ConnectFkToPk);
 		center_pnts_rb->setChecked(config_params[Attributes::Connection][Attributes::Mode]==Attributes::ConnectCenterPnts);
@@ -129,19 +129,19 @@ void RelationshipConfigWidget::loadConfiguration(void)
 }
 
 void RelationshipConfigWidget::saveConfiguration(void)
-{  
+{
 	try
 	{
 		QString patterns_sch, root_dir;
 
-		root_dir=GlobalAttributes::TmplConfigurationDir +
-				 GlobalAttributes::DirSeparator;
+		root_dir=GlobalAttributes::get().TmplConfigurationDir +
+				 GlobalAttributes::get().DirSeparator;
 
 		patterns_sch=root_dir +
-					 GlobalAttributes::SchemasDir +
-					 GlobalAttributes::DirSeparator +
+					 GlobalAttributes::get().SchemasDir +
+					 GlobalAttributes::get().DirSeparator +
 					 Attributes::Patterns +
-					 GlobalAttributes::SchemaExt;
+					 GlobalAttributes::get().SchemaExt;
 
 
 		if(crows_foot_rb->isChecked())
@@ -168,7 +168,7 @@ void RelationshipConfigWidget::saveConfiguration(void)
 			config_params[Attributes::NamePatterns][Attributes::Patterns]+=schparser.getCodeDefinition(patterns_sch, itr.second);
 		}
 
-		BaseConfigWidget::saveConfiguration(GlobalAttributes::RelationshipsConf, config_params);
+		BaseConfigWidget::saveConfiguration(GlobalAttributes::get().RelationshipsConf, config_params);
 	}
 	catch(Exception &e)
 	{
@@ -195,7 +195,7 @@ void RelationshipConfigWidget::restoreDefaults(void)
 {
 	try
 	{
-		BaseConfigWidget::restoreDefaults(GlobalAttributes::RelationshipsConf, false);
+		BaseConfigWidget::restoreDefaults(GlobalAttributes::get().RelationshipsConf, false);
 		this->loadConfiguration();
 		setConfigurationChanged(true);
 	}

--- a/libpgmodeler_ui/src/relationshipwidget.cpp
+++ b/libpgmodeler_ui/src/relationshipwidget.cpp
@@ -55,19 +55,19 @@ RelationshipWidget::RelationshipWidget(QWidget *parent): BaseObjectWidget(parent
 
 		table1_hl=nullptr;
 		table1_hl=new SyntaxHighlighter(ref_table_txt, true);
-		table1_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		table1_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 		table2_hl=nullptr;
 		table2_hl=new SyntaxHighlighter(recv_table_txt, true);
-		table2_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		table2_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 		for(int i=0; i < pattern_fields.size(); i++)
 		{
 			patterns_hl[i]=new SyntaxHighlighter(qobject_cast<QPlainTextEdit *>(pattern_fields[i]), true);
-			patterns_hl[i]->loadConfiguration(GlobalAttributes::ConfigurationsDir +
-											  GlobalAttributes::DirSeparator +
-											  GlobalAttributes::PatternHighlightConf +
-											  GlobalAttributes::ConfigurationExt);
+			patterns_hl[i]->loadConfiguration(GlobalAttributes::get().ConfigurationsDir +
+											  GlobalAttributes::get().DirSeparator +
+											  GlobalAttributes::get().PatternHighlightConf +
+											  GlobalAttributes::get().ConfigurationExt);
 		}
 
 		attributes_tab=new ObjectsTableWidget(ObjectsTableWidget::AllButtons ^
@@ -163,7 +163,7 @@ RelationshipWidget::RelationshipWidget(QWidget *parent): BaseObjectWidget(parent
 
 		part_bound_expr_txt=new NumberedTextEditor(this, true);
 		part_bound_expr_hl=new SyntaxHighlighter(part_bound_expr_txt);
-		part_bound_expr_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		part_bound_expr_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 		dynamic_cast<QGridLayout *>(part_bound_expr_gb->layout())->addWidget(part_bound_expr_txt, 1, 0);
 
 		connect(deferrable_chk, SIGNAL(toggled(bool)), deferral_cmb, SLOT(setEnabled(bool)));

--- a/libpgmodeler_ui/src/rulewidget.cpp
+++ b/libpgmodeler_ui/src/rulewidget.cpp
@@ -28,10 +28,10 @@ RuleWidget::RuleWidget(QWidget *parent): BaseObjectWidget(parent, ObjectType::Ru
 		Ui_RuleWidget::setupUi(this);
 
 		cond_expr_hl=new SyntaxHighlighter(cond_expr_txt, false, true);
-		cond_expr_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		cond_expr_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 		command_hl=new SyntaxHighlighter(comando_txt, false, true);
-		command_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		command_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 		command_cp=new CodeCompletionWidget(comando_txt);
 
 		commands_tab=new ObjectsTableWidget(ObjectsTableWidget::AllButtons ^ ObjectsTableWidget::DuplicateButton, true, this);

--- a/libpgmodeler_ui/src/snippetsconfigwidget.cpp
+++ b/libpgmodeler_ui/src/snippetsconfigwidget.cpp
@@ -64,7 +64,7 @@ SnippetsConfigWidget::SnippetsConfigWidget(QWidget * parent) : BaseConfigWidget(
 	try
 	{
 		snippet_hl=new SyntaxHighlighter(snippet_txt);
-		snippet_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		snippet_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 	}
 	catch(Exception &e)
 	{
@@ -157,7 +157,7 @@ vector<attribs_map> SnippetsConfigWidget::getAllSnippets(void)
 }
 
 QString SnippetsConfigWidget::parseSnippet(attribs_map snippet, attribs_map attribs)
-{ 
+{
 	SchemaParser schparser;
 	QStringList aux_attribs;
 	QString buf=snippet[Attributes::Contents];
@@ -270,7 +270,7 @@ void SnippetsConfigWidget::loadConfiguration(void)
 		QStringList inv_snippets;
 
 		this->resetForm();
-		BaseConfigWidget::loadConfiguration(GlobalAttributes::SnippetsConf, config_params, { Attributes::Id });
+		BaseConfigWidget::loadConfiguration(GlobalAttributes::get().SnippetsConf, config_params, { Attributes::Id });
 
 		//Check if there are invalid snippets loaded
 		for(auto &snip : config_params)
@@ -442,17 +442,17 @@ void SnippetsConfigWidget::parseSnippet(void)
 }
 
 void SnippetsConfigWidget::saveConfiguration(void)
-{ 
+{
 	try
 	{
-		QString root_dir=GlobalAttributes::TmplConfigurationDir +
-						 GlobalAttributes::DirSeparator,
+		QString root_dir=GlobalAttributes::get().TmplConfigurationDir +
+						 GlobalAttributes::get().DirSeparator,
 
 				snippet_sch=root_dir +
-							GlobalAttributes::SchemasDir +
-							GlobalAttributes::DirSeparator +
+							GlobalAttributes::get().SchemasDir +
+							GlobalAttributes::get().DirSeparator +
 							Attributes::Snippet +
-							GlobalAttributes::SchemaExt;
+							GlobalAttributes::get().SchemaExt;
 
 		attribs_map attribs;
 		ObjectType obj_type;
@@ -471,8 +471,8 @@ void SnippetsConfigWidget::saveConfiguration(void)
 			}
 		}
 
-		config_params[GlobalAttributes::SnippetsConf]=attribs;
-		BaseConfigWidget::saveConfiguration(GlobalAttributes::SnippetsConf, config_params);
+		config_params[GlobalAttributes::get().SnippetsConf]=attribs;
+		BaseConfigWidget::saveConfiguration(GlobalAttributes::get().SnippetsConf, config_params);
 	}
 	catch(Exception &e)
 	{
@@ -484,7 +484,7 @@ void SnippetsConfigWidget::restoreDefaults(void)
 {
 	try
 	{
-		BaseConfigWidget::restoreDefaults(GlobalAttributes::SnippetsConf, false);
+		BaseConfigWidget::restoreDefaults(GlobalAttributes::get().SnippetsConf, false);
 		this->loadConfiguration();
 		setConfigurationChanged(true);
 	}

--- a/libpgmodeler_ui/src/sourcecodewidget.cpp
+++ b/libpgmodeler_ui/src/sourcecodewidget.cpp
@@ -242,10 +242,10 @@ void SourceCodeWidget::setAttributes(DatabaseModel *model, BaseObject *object)
 			obj_icon_lbl->setPixmap(QPixmap(PgModelerUiNs::getIconPath(object->getObjectType())));
 
 			if(!hl_sqlcode->isConfigurationLoaded())
-				hl_sqlcode->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+				hl_sqlcode->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 			if(!hl_xmlcode->isConfigurationLoaded())
-				hl_xmlcode->loadConfiguration(GlobalAttributes::XMLHighlightConfPath);
+				hl_xmlcode->loadConfiguration(GlobalAttributes::get().XMLHighlightConfPath);
 
 			generateSourceCode();
 		}

--- a/libpgmodeler_ui/src/sqlexecutionwidget.cpp
+++ b/libpgmodeler_ui/src/sqlexecutionwidget.cpp
@@ -53,10 +53,10 @@ SQLExecutionWidget::SQLExecutionWidget(QWidget * parent) : QWidget(parent)
 	connect(find_history_wgt->hide_tb, SIGNAL(clicked(bool)), find_history_parent, SLOT(hide()));
 
 	sql_cmd_hl=new SyntaxHighlighter(sql_cmd_txt, false);
-	sql_cmd_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+	sql_cmd_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 	cmd_history_hl=new SyntaxHighlighter(cmd_history_txt, false);
-	cmd_history_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+	cmd_history_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 	results_parent->setVisible(false);
 	output_tbw->setTabEnabled(0, false);
@@ -923,7 +923,7 @@ void SQLExecutionWidget::toggleOutputPane(bool visible)
 }
 
 void SQLExecutionWidget::configureSnippets(void)
-{ 
+{
 	SnippetsConfigWidget::configureSnippetsMenu(&snippets_menu);
 	code_compl_wgt->configureCompletion(nullptr, sql_cmd_hl);
 }
@@ -943,30 +943,30 @@ void SQLExecutionWidget::saveSQLHistory(void)
 			attribs[Attributes::Connection] = hist.first;
 			attribs[Attributes::Commands] = hist.second;
 			schparser.ignoreEmptyAttributes(true);
-			commands += schparser.getCodeDefinition(GlobalAttributes::TmplConfigurationDir +
-																							GlobalAttributes::DirSeparator +
-																							GlobalAttributes::SchemasDir +
-																							GlobalAttributes::DirSeparator +
+			commands += schparser.getCodeDefinition(GlobalAttributes::get().TmplConfigurationDir +
+																							GlobalAttributes::get().DirSeparator +
+																							GlobalAttributes::get().SchemasDir +
+																							GlobalAttributes::get().DirSeparator +
 																							Attributes::Commands +
-																							GlobalAttributes::SchemaExt, attribs);
+																							GlobalAttributes::get().SchemaExt, attribs);
 		}
 
-		schparser.loadFile(GlobalAttributes::TmplConfigurationDir +
-											 GlobalAttributes::DirSeparator +
-											 GlobalAttributes::SchemasDir +
-											 GlobalAttributes::DirSeparator +
-											 GlobalAttributes::SQLHistoryConf +
-											 GlobalAttributes::SchemaExt);
+		schparser.loadFile(GlobalAttributes::get().TmplConfigurationDir +
+											 GlobalAttributes::get().DirSeparator +
+											 GlobalAttributes::get().SchemasDir +
+											 GlobalAttributes::get().DirSeparator +
+											 GlobalAttributes::get().SQLHistoryConf +
+											 GlobalAttributes::get().SchemaExt);
 
 		attribs.clear();
 		attribs[Attributes::Commands] = commands;
 		buffer.append(schparser.getCodeDefinition(attribs));
 
 
-		file.setFileName(GlobalAttributes::ConfigurationsDir +
-										 GlobalAttributes::DirSeparator +
-										 GlobalAttributes::SQLHistoryConf +
-										 GlobalAttributes::ConfigurationExt);
+		file.setFileName(GlobalAttributes::get().ConfigurationsDir +
+										 GlobalAttributes::get().DirSeparator +
+										 GlobalAttributes::get().SQLHistoryConf +
+										 GlobalAttributes::get().ConfigurationExt);
 
 		if(!file.open(QFile::WriteOnly))
 			throw Exception(Exception::getErrorMessage(ErrorCode::FileDirectoryNotAccessed).arg(file.fileName()),
@@ -988,18 +988,18 @@ void SQLExecutionWidget::loadSQLHistory(void)
 		XmlParser xmlparser;
 		attribs_map attribs;
 
-		xmlparser.setDTDFile(GlobalAttributes::TmplConfigurationDir +
-												 GlobalAttributes::DirSeparator +
-												 GlobalAttributes::ObjectDTDDir +
-												 GlobalAttributes::DirSeparator +
-												 GlobalAttributes::SQLHistoryConf +
-												 GlobalAttributes::ObjectDTDExt,
-												 GlobalAttributes::SQLHistoryConf);
+		xmlparser.setDTDFile(GlobalAttributes::get().TmplConfigurationDir +
+												 GlobalAttributes::get().DirSeparator +
+												 GlobalAttributes::get().ObjectDTDDir +
+												 GlobalAttributes::get().DirSeparator +
+												 GlobalAttributes::get().SQLHistoryConf +
+												 GlobalAttributes::get().ObjectDTDExt,
+												 GlobalAttributes::get().SQLHistoryConf);
 
-		xmlparser.loadXMLFile(GlobalAttributes::ConfigurationsDir +
-													GlobalAttributes::DirSeparator +
-													GlobalAttributes::SQLHistoryConf +
-													GlobalAttributes::ConfigurationExt);
+		xmlparser.loadXMLFile(GlobalAttributes::get().ConfigurationsDir +
+													GlobalAttributes::get().DirSeparator +
+													GlobalAttributes::get().SQLHistoryConf +
+													GlobalAttributes::get().ConfigurationExt);
 
 		cmd_history.clear();
 
@@ -1036,10 +1036,10 @@ void SQLExecutionWidget::destroySQLHistory(void)
 
 	if(msg_box.result() == QDialog::Accepted)
 	{
-		QFile::remove(GlobalAttributes::ConfigurationsDir +
-									GlobalAttributes::DirSeparator +
-									GlobalAttributes::SQLHistoryConf +
-									GlobalAttributes::ConfigurationExt);
+		QFile::remove(GlobalAttributes::get().ConfigurationsDir +
+									GlobalAttributes::get().DirSeparator +
+									GlobalAttributes::get().SQLHistoryConf +
+									GlobalAttributes::get().ConfigurationExt);
 
 		SQLExecutionWidget::cmd_history.clear();
 	}

--- a/libpgmodeler_ui/src/sqltoolwidget.cpp
+++ b/libpgmodeler_ui/src/sqltoolwidget.cpp
@@ -43,7 +43,7 @@ SQLToolWidget::SQLToolWidget(QWidget * parent) : QWidget(parent)
 	sourcecode_txt->setReadOnly(true);
 
 	sourcecode_hl=new SyntaxHighlighter(sourcecode_txt);
-	sourcecode_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+	sourcecode_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 	vbox->setContentsMargins(4,4,4,4);
 	vbox->addWidget(sourcecode_txt);

--- a/libpgmodeler_ui/src/syntaxhighlighter.cpp
+++ b/libpgmodeler_ui/src/syntaxhighlighter.cpp
@@ -372,13 +372,13 @@ void SyntaxHighlighter::loadConfiguration(const QString &filename)
 		{
 			clearConfiguration();
 			xmlparser.restartParser();
-			xmlparser.setDTDFile(GlobalAttributes::TmplConfigurationDir +
-								 GlobalAttributes::DirSeparator +
-								 GlobalAttributes::ObjectDTDDir +
-								 GlobalAttributes::DirSeparator +
-								 GlobalAttributes::CodeHighlightConf +
-								 GlobalAttributes::ObjectDTDExt,
-								 GlobalAttributes::CodeHighlightConf);
+			xmlparser.setDTDFile(GlobalAttributes::get().TmplConfigurationDir +
+								 GlobalAttributes::get().DirSeparator +
+								 GlobalAttributes::get().ObjectDTDDir +
+								 GlobalAttributes::get().DirSeparator +
+								 GlobalAttributes::get().CodeHighlightConf +
+								 GlobalAttributes::get().ObjectDTDExt,
+								 GlobalAttributes::get().CodeHighlightConf);
 
 			xmlparser.loadXMLFile(filename);
 

--- a/libpgmodeler_ui/src/triggerwidget.cpp
+++ b/libpgmodeler_ui/src/triggerwidget.cpp
@@ -27,7 +27,7 @@ TriggerWidget::TriggerWidget(QWidget *parent): BaseObjectWidget(parent, ObjectTy
 		Ui_TriggerWidget::setupUi(this);
 
 		cond_expr_hl=new SyntaxHighlighter(cond_expr_txt, false, true);
-		cond_expr_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		cond_expr_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
 		columns_tab=new ObjectsTableWidget(ObjectsTableWidget::AllButtons ^
 										  (ObjectsTableWidget::EditButton |

--- a/libpgmodeler_ui/src/updatenotifierwidget.cpp
+++ b/libpgmodeler_ui/src/updatenotifierwidget.cpp
@@ -37,8 +37,8 @@ UpdateNotifierWidget::UpdateNotifierWidget(QWidget *parent) : QWidget(parent)
 	connect(&update_chk_manager, SIGNAL(finished(QNetworkReply*)), this, SLOT(handleUpdateChecked(QNetworkReply*)));
 
 	//C++11 lambda slots
-	connect(get_source_tb, &QToolButton::clicked, this, [&](){ activateLink(GlobalAttributes::PgModelerSourceURL); });
-	connect(get_binary_tb, &QToolButton::clicked, this, [&](){ activateLink(GlobalAttributes::PgModelerDownloadURL); });
+	connect(get_source_tb, &QToolButton::clicked, this, [&](){ activateLink(GlobalAttributes::get().PgModelerSourceURL); });
+	connect(get_binary_tb, &QToolButton::clicked, this, [&](){ activateLink(GlobalAttributes::get().PgModelerDownloadURL); });
 
 
 	connect(hide_tb, &QToolButton::clicked, this,
@@ -97,7 +97,7 @@ void UpdateNotifierWidget::activateLink(const QString &link)
 
 void UpdateNotifierWidget::checkForUpdate(void)
 {
-	QUrl url(GlobalAttributes::PgModelerUpdateCheckURL + GlobalAttributes::PgModelerVersion);
+	QUrl url(GlobalAttributes::get().PgModelerUpdateCheckURL + GlobalAttributes::get().PgModelerVersion);
 	QNetworkRequest req(url);
 
 	req.setRawHeader("User-Agent", "pgModelerUpdateCheck");
@@ -124,8 +124,8 @@ void UpdateNotifierWidget::handleUpdateChecked(QNetworkReply *reply)
 		{
 			QString url=reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toString();
 
-			if(http_status==302 && !url.startsWith(GlobalAttributes::PgModelerSite))
-				url.prepend(GlobalAttributes::PgModelerSite);
+			if(http_status==302 && !url.startsWith(GlobalAttributes::get().PgModelerSite))
+				url.prepend(GlobalAttributes::get().PgModelerSite);
 
 			QNetworkRequest req(url);
 			update_chk_reply=update_chk_manager.get(req);

--- a/libpgmodeler_ui/src/viewwidget.cpp
+++ b/libpgmodeler_ui/src/viewwidget.cpp
@@ -40,14 +40,14 @@ ViewWidget::ViewWidget(QWidget *parent): BaseObjectWidget(parent, ObjectType::Vi
 		code_txt=new NumberedTextEditor(this);
 		code_txt->setReadOnly(true);
 		code_hl=new SyntaxHighlighter(code_txt);
-		code_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		code_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 		vbox=new QVBoxLayout(code_prev_tab);
 		vbox->setContentsMargins(4,4,4,4);
 		vbox->addWidget(code_txt);
 
 		cte_expression_txt=new NumberedTextEditor(this, true);
 		cte_expression_hl=new SyntaxHighlighter(cte_expression_txt);
-		cte_expression_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+		cte_expression_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 		vbox=new QVBoxLayout(cte_tab);
 		vbox->setContentsMargins(4,4,4,4);
 		vbox->addWidget(cte_expression_txt);

--- a/libutils/src/globalattributes.cpp
+++ b/libutils/src/globalattributes.cpp
@@ -213,12 +213,14 @@ QString GlobalAttributes::getPathFromEnv(const QString &varname, const QString &
 
 GlobalAttributes& GlobalAttributes::create(const QApplication& app)
 {
-	GlobalAttributes::get()._instance = new GlobalAttributes(app);
+	// TODO Consider throwing an exception in case of multiple calls, not designed to be.
+	if (!GlobalAttributes::_instance)
+		GlobalAttributes::_instance = new GlobalAttributes(app);
 
-	return *GlobalAttributes::get()._instance;
+	return *GlobalAttributes::_instance;
 }
 
 const GlobalAttributes& GlobalAttributes::get()
 {
-	return *GlobalAttributes::get()._instance;
+	return *GlobalAttributes::_instance;
 }

--- a/libutils/src/globalattributes.cpp
+++ b/libutils/src/globalattributes.cpp
@@ -169,8 +169,7 @@ GlobalAttributes::GlobalAttributes(const QApplication& app) :
 	PgModelerAppPath(getPathFromEnv(
 		QString("PGMODELER_APP_PATH"),
 		QString(BINDIR)				+ QString("/pgmodeler"),
-		app.applicationDirPath()	+ QString("/pgmodeler")));
-
+		app.applicationDirPath()	+ QString("/pgmodeler")))
 #else
 	PgModelerCHandlerPath(getPathFromEnv(
 		QString("PGMODELER_CHANDLER_PATH"),

--- a/libutils/src/globalattributes.cpp
+++ b/libutils/src/globalattributes.cpp
@@ -20,189 +20,206 @@
 #include <QCoreApplication>
 #include <QTextStream>
 
-namespace GlobalAttributes {
-	const QString
-	PgModelerVersion=QString("0.9.2")
+GlobalAttributes* GlobalAttributes::_instance = NULL;
+
+GlobalAttributes::GlobalAttributes(const QApplication& app) :
+	PgModelerVersion(QString("0.9.2")
 
 	/* Appending the snapshot build number to the version number
 	 * when the external variable SNAPSHOT_BUILD is defined */
 	#if defined(SNAPSHOT_BUILD)
 		+ QString("_snapshot") + BUILDNUM
 	#endif
-	,
+	),
 	/****/
 
-	PgModelerAppName=QString("pgmodeler"),
-	PgModelerURI=QString("pgmodeler.io"),
-	PgModelerReverseURI=QString("io.pgmodeler"),
-	PgModelerBuildNumber=QString(BUILDNUM),
-	PgModelerSite=QString("https://pgmodeler.io"),
-	PgModelerSupport=QString("https://pgmodeler.io/support/docs"),
-	PgModelerSourceURL=QString("https://github.com/pgmodeler/pgmodeler/releases"),
-	PgModelerDownloadURL=QString("%1/download").arg(PgModelerSite),
-	PgModelerDonateURL=QString("%1/#donationForm").arg(PgModelerSite),
-	PgModelerUpdateCheckURL=QString("%1/checkupdate?version=").arg(PgModelerSite),
+	PgModelerAppName(QString("pgmodeler")),
+	PgModelerURI(QString("pgmodeler.io")),
+	PgModelerReverseURI(QString("io.pgmodeler")),
+	PgModelerBuildNumber(QString(BUILDNUM)),
+	PgModelerSite(QString("https://pgmodeler.io")),
+	PgModelerSupport(QString("https://pgmodeler.io/support/docs")),
+	PgModelerSourceURL(QString("https://github.com/pgmodeler/pgmodeler/releases")),
+	PgModelerDownloadURL(QString("%1/download").arg(PgModelerSite)),
+	PgModelerDonateURL(QString("%1/#donationForm").arg(PgModelerSite)),
+	PgModelerUpdateCheckURL(QString("%1/checkupdate?version=").arg(PgModelerSite)),
 
-	BugReportEmail=QString("bug@pgmodeler.io"),
-	BugReportFile=QString("pgmodeler%1.bug"),
-	StacktraceFile=QString(".stacktrace"),
+	BugReportEmail(QString("bug@pgmodeler.io")),
+	BugReportFile(QString("pgmodeler%1.bug")),
+	StacktraceFile(QString(".stacktrace")),
 
-	DirSeparator=QString("/"),
-	DefaultConfsDir=QString("defaults"),
-	ConfsBackupsDir=QString("backups"),
-	SchemasDir=QString("schemas"),
-	SQLSchemaDir=QString("sql"),
-	XMLSchemaDir=QString("xml"),
-	DataDictSchemaDir=QString("datadict"),
-	AlterSchemaDir=QString("alter"),
-	SchemaExt=QString(".sch"),
-	ObjectDTDDir=QString("dtd"),
-	ObjectDTDExt=QString(".dtd"),
-	RootDTD=QString("dbmodel"),
-	MetadataDTD=QString("metadata"),
-	ConfigurationExt=QString(".conf"),
-	HighlightFileSuffix=QString("-highlight"),
+	DirSeparator(QString("/")),
+	DefaultConfsDir(QString("defaults")),
+	ConfsBackupsDir(QString("backups")),
+	SchemasDir(QString("schemas")),
+	SQLSchemaDir(QString("sql")),
+	XMLSchemaDir(QString("xml")),
+	DataDictSchemaDir(QString("datadict")),
+	AlterSchemaDir(QString("alter")),
+	SchemaExt(QString(".sch")),
+	ObjectDTDDir(QString("dtd")),
+	ObjectDTDExt(QString(".dtd")),
+	RootDTD(QString("dbmodel")),
+	MetadataDTD(QString("metadata")),
+	ConfigurationExt(QString(".conf")),
+	HighlightFileSuffix(QString("-highlight")),
 
-	CodeHighlightConf=QString("source-code-highlight"),
-	ObjectsStyleConf=QString("objects-style"),
-	GeneralConf=QString("pgmodeler"),
-	ConnectionsConf=QString("connections"),
-	RelationshipsConf=QString("relationships"),
-	SnippetsConf=QString("snippets"),
-	SQLHistoryConf=QString("sql-history"),
-	DiffPresetsConf=QString("diff-presets"),
+	CodeHighlightConf(QString("source-code-highlight")),
+	ObjectsStyleConf(QString("objects-style")),
+	GeneralConf(QString("pgmodeler")),
+	ConnectionsConf(QString("connections")),
+	RelationshipsConf(QString("relationships")),
+	SnippetsConf(QString("snippets")),
+	DiffPresetsConf(QString("diff-presets")),
 
-	SQLHighlightConf=QString("sql-highlight"),
-	XMLHighlightConf=QString("xml-highlight"),
-	PatternHighlightConf=QString("pattern-highlight"),
+	SQLHighlightConf(QString("sql-highlight")),
+	XMLHighlightConf(QString("xml-highlight")),
+	PatternHighlightConf(QString("pattern-highlight")),
+	SQLHistoryConf(QString("sql-history")),
 
-	ExampleModel=QString("example.dbm"),
-	UiStyleConf=QString("ui-style"),
+	ExampleModel(QString("example.dbm")),
+	UiStyleConf(QString("ui-style")),
 
-	DefaultQtStyle=QString("Fusion"),
-	UiStyleOption=QString("-style"),
+	DefaultQtStyle(QString("Fusion")),
+	UiStyleOption(QString("-style")),
 
-	SchemasRootDir			= getPathFromEnv(
-								QString("PGMODELER_SCHEMAS_DIR"),
-								QString(SCHEMASDIR),
-								QCoreApplication::applicationDirPath() + QString("/schemas")),
-	LanguagesDir			= getPathFromEnv(
-								QString("PGMODELER_LANG_DIR"),
-								QString(LANGDIR),
-								QCoreApplication::applicationDirPath() + QString("/lang")),
-	SamplesDir				= getPathFromEnv(
-								QString("PGMODELER_SAMPLES_DIR"),
-								QString(SAMPLESDIR),
-								QCoreApplication::applicationDirPath() + QString("/samples")),
-	TmplConfigurationDir	= getPathFromEnv(
-								QString("PGMODELER_TMPL_CONF_DIR"),
-								QString(CONFDIR),
-								QCoreApplication::applicationDirPath() + QString("/conf")),
+	SchemasRootDir(getPathFromEnv(
+		QString("PGMODELER_SCHEMAS_DIR"),
+		QString(SCHEMASDIR),
+		app.applicationDirPath() + QString("/schemas"))),
+
+	LanguagesDir(getPathFromEnv(
+		QString("PGMODELER_LANG_DIR"),
+		QString(LANGDIR),
+		app.applicationDirPath() + QString("/lang"))),
+
+	SamplesDir(getPathFromEnv(
+		QString("PGMODELER_SAMPLES_DIR"),
+		QString(SAMPLESDIR),
+		app.applicationDirPath() + QString("/samples"))),
+
+	TmplConfigurationDir(getPathFromEnv(
+		QString("PGMODELER_TMPL_CONF_DIR"),
+		QString(CONFDIR),
+		app.applicationDirPath() + QString("/conf"))),
 
 	//Currently, plugins folder is auto-created when missing so it can't be resolved by getPathFromEnv()
-	PluginsDir = getenv("PGMODELER_PLUGINS_DIR")
-					? QString(getenv("PGMODELER_PLUGINS_DIR")).replace('\\','/')
-					: QString(PLUGINSDIR),
+	PluginsDir
+	(
+		getenv("PGMODELER_PLUGINS_DIR")
+			? QString(getenv("PGMODELER_PLUGINS_DIR")).replace('\\','/')
+			: QString(PLUGINSDIR)
+	),
 
 #if defined(Q_OS_MAC)
-	ConfigurationsDir	=getPathFromEnv(
-							QString("PGMODELER_CONF_DIR"),
-							QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)
-							+ QString("/%1").arg(PgModelerReverseURI)),
+	ConfigurationsDir(getPathFromEnv(
+		QString("PGMODELER_CONF_DIR"),
+		QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)
+		+ QString("/%1").arg(PgModelerReverseURI))),
 
-	TemporaryDir		=getPathFromEnv(
-							QString("PGMODELER_TMP_DIR"),
-							QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)
-							+ QString("/%1/tmp").arg(PgModelerReverseURI)),
+	TemporaryDir(getPathFromEnv(
+		QString("PGMODELER_TMP_DIR"),
+		QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)
+		+ QString("/%1/tmp").arg(PgModelerReverseURI))),
 
 #elif defined(Q_OS_LINUX)
-	ConfigurationsDir	= getPathFromEnv(
-							QString("PGMODELER_CONF_DIR"),
-							QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)
-							+ QString("/%1").arg(PgModelerAppName)),
+	ConfigurationsDir(getPathFromEnv(
+		QString("PGMODELER_CONF_DIR"),
+		QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)
+		+ QString("/%1").arg(PgModelerAppName))),
 
-	TemporaryDir		= getPathFromEnv(
-							QString("PGMODELER_TMP_DIR"),
-							QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)
-							+ QString("/%1/tmp").arg(PgModelerAppName)),
+	TemporaryDir(getPathFromEnv(
+		QString("PGMODELER_TMP_DIR"),
+		QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)
+		+ QString("/%1/tmp").arg(PgModelerAppName))),
 #else
-	ConfigurationsDir	= getPathFromEnv(
-							QString("PGMODELER_CONF_DIR"),
-							QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
-							+ QString("/%1").arg(PgModelerAppName)),
+	ConfigurationsDir(getPathFromEnv(
+		QString("PGMODELER_CONF_DIR"),
+		QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
+		+ QString("/%1").arg(PgModelerAppName))),
 
-	TemporaryDir		= getPathFromEnv(
-							QString("PGMODELER_TMP_DIR"),
-							QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
-							+ QString("/%1/tmp").arg(PgModelerAppName)),
+	TemporaryDir(getPathFromEnv(
+		QString("PGMODELER_TMP_DIR"),
+		QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
+		+ QString("/%1/tmp").arg(PgModelerAppName))),
 #endif
 
-	SQLHighlightConfPath = ConfigurationsDir + DirSeparator + SQLHighlightConf + ConfigurationExt,
-	XMLHighlightConfPath = ConfigurationsDir + DirSeparator + XMLHighlightConf + ConfigurationExt,
+	SQLHighlightConfPath(ConfigurationsDir + DirSeparator + SQLHighlightConf + ConfigurationExt),
+	XMLHighlightConfPath(ConfigurationsDir + DirSeparator + XMLHighlightConf + ConfigurationExt),
 
 #if defined(Q_OS_UNIX)
 #if defined(Q_OS_MAC)
 	//For MacOSX the crash handler path is fixed (inside bundle)
-	PgModelerCHandlerPath = getPathFromEnv(
-								QString("PGMODELER_CHANDLER_PATH"),
-								QString(BINDIR)							+ QString("/pgmodeler-ch"),
-								QCoreApplication::applicationDirPath()	+ QString("/pgmodeler-ch")),
+	PgModelerCHandlerPath(getPathFromEnv(
+		QString("PGMODELER_CHANDLER_PATH"),
+		QString(BINDIR)				+ QString("/pgmodeler-ch"),
+		app.applicationDirPath()	+ QString("/pgmodeler-ch"))),
 #else
-	PgModelerCHandlerPath = getPathFromEnv(
-								QString("PGMODELER_CHANDLER_PATH"),
-								QString(PRIVATEBINDIR)					+ QString("/pgmodeler-ch"),
-								QCoreApplication::applicationDirPath()	+ QString("/pgmodeler-ch")),
+	PgModelerCHandlerPath(getPathFromEnv(
+		QString("PGMODELER_CHANDLER_PATH"),
+		QString(PRIVATEBINDIR)		+ QString("/pgmodeler-ch"),
+		app.applicationDirPath()	+ QString("/pgmodeler-ch"))),
 #endif
 
-	PgModelerCLIPath = getPathFromEnv(
-						QString("PGMODELER_CLI_PATH"),
-						QString(BINDIR)							+ QString("/pgmodeler-cli"),
-						QCoreApplication::applicationDirPath()	+ QString("/pgmodeler-cli")),
+	PgModelerCLIPath(getPathFromEnv(
+		QString("PGMODELER_CLI_PATH"),
+		QString(BINDIR)				+ QString("/pgmodeler-cli"),
+		app.applicationDirPath()	+ QString("/pgmodeler-cli"))),
 
-	PgModelerAppPath = getPathFromEnv(
-						QString("PGMODELER_APP_PATH"),
-						QString(BINDIR)							+ QString("/pgmodeler"),
-						QCoreApplication::applicationDirPath()	+ QString("/pgmodeler"));
-
+	PgModelerAppPath(getPathFromEnv(
+		QString("PGMODELER_APP_PATH"),
+		QString(BINDIR)				+ QString("/pgmodeler"),
+		app.applicationDirPath()	+ QString("/pgmodeler")));
 
 #else
-	PgModelerCHandlerPath = getPathFromEnv(
-								QString("PGMODELER_CHANDLER_PATH"),
-								QString(PRIVATEBINDIR)					+ QString("\\pgmodeler-ch.exe"),
-								QCoreApplication::applicationDirPath()	+ QString("\\pgmodeler-ch.exe")),
+	PgModelerCHandlerPath(getPathFromEnv(
+		QString("PGMODELER_CHANDLER_PATH"),
+		QString(PRIVATEBINDIR)		+ QString("\\pgmodeler-ch.exe"),
+		app.applicationDirPath()	+ QString("\\pgmodeler-ch.exe"))),
 
-	PgModelerCLIPath = getPathFromEnv(
-						QString("PGMODELER_CLI_PATH"),
-						QString(PRIVATEBINDIR)					+ QString("\\pgmodeler-cli.exe"),
-						QCoreApplication::applicationDirPath()	+ QString("\\pgmodeler-cli.exe")),
+	PgModelerCLIPath(getPathFromEnv(
+		QString("PGMODELER_CLI_PATH"),
+		QString(PRIVATEBINDIR)		+ QString("\\pgmodeler-cli.exe"),
+		app.applicationDirPath()	+ QString("\\pgmodeler-cli.exe"))),
 
-	PgModelerAppPath = getPathFromEnv(
-						QString("PGMODELER_APP_PATH"),
-						QString(BINDIR)							+ QString("\\pgmodeler.exe"),
-						QCoreApplication::applicationDirPath()	+ QString("\\pgmodeler.exe"));
-
+	PgModelerAppPath(getPathFromEnv(
+		QString("PGMODELER_APP_PATH"),
+		QString(BINDIR)				+ QString("\\pgmodeler.exe"),
+		app.applicationDirPath()	+ QString("\\pgmodeler.exe")))
 #endif
 
 #ifdef DEMO_VERSION
 	//Maximum object creation counter for demo version
-	const unsigned MaxObjectCount=15;
+	, MaxObjectCount(15)
 #endif
+{
+}
 
+QString GlobalAttributes::getPathFromEnv(const QString &varname, const QString &default_val, const QString &fallback_val)
+{
+	QFileInfo fi;
+	QStringList paths={ QDir::toNativeSeparators(getenv(varname.toStdString().c_str())),
+						QDir::toNativeSeparators(default_val) };
 
-	QString getPathFromEnv(const QString &varname, const QString &default_val, const QString &fallback_val)
+	for(int i=0; i < 2; i++)
 	{
-		QFileInfo fi;
-		QStringList paths={ QDir::toNativeSeparators(getenv(varname.toStdString().c_str())),
-							QDir::toNativeSeparators(default_val) };
-
-		for(int i=0; i < 2; i++)
-		{
-			fi.setFile(paths[i]);
-			if(fi.exists() || (i==1 && fallback_val.isEmpty()))
-				return(paths[i].replace('\\','/'));
-		}
-
-		fi.setFile(fallback_val);
-		return(fi.absoluteFilePath());
+		fi.setFile(paths[i]);
+		if(fi.exists() || (i==1 && fallback_val.isEmpty()))
+			return(paths[i].replace('\\','/'));
 	}
+
+	fi.setFile(fallback_val);
+	return(fi.absoluteFilePath());
+}
+
+GlobalAttributes& GlobalAttributes::create(const QApplication& app)
+{
+	GlobalAttributes::get()._instance = new GlobalAttributes(app);
+
+	return *GlobalAttributes::get()._instance;
+}
+
+const GlobalAttributes& GlobalAttributes::get()
+{
+	return *GlobalAttributes::get()._instance;
 }

--- a/libutils/src/globalattributes.cpp
+++ b/libutils/src/globalattributes.cpp
@@ -82,71 +82,104 @@ namespace GlobalAttributes {
 	DefaultQtStyle=QString("Fusion"),
 	UiStyleOption=QString("-style"),
 
-	SchemasRootDir=getPathFromEnv(QString("PGMODELER_SCHEMAS_DIR"), QString(SCHEMASDIR), QString("./schemas")),
-	LanguagesDir=getPathFromEnv(QString("PGMODELER_LANG_DIR"), QString(LANGDIR), QString("./lang")),
-	SamplesDir=getPathFromEnv(QString("PGMODELER_SAMPLES_DIR"), QString(SAMPLESDIR), QString("./samples")),
-	TmplConfigurationDir=getPathFromEnv(QString("PGMODELER_TMPL_CONF_DIR"), QString(CONFDIR), QString("./conf")),
+	SchemasRootDir			= getPathFromEnv(
+								QString("PGMODELER_SCHEMAS_DIR"),
+								QString(SCHEMASDIR),
+								QCoreApplication::applicationDirPath() + QString("/schemas")),
+	LanguagesDir			= getPathFromEnv(
+								QString("PGMODELER_LANG_DIR"),
+								QString(LANGDIR),
+								QCoreApplication::applicationDirPath() + QString("/lang")),
+	SamplesDir				= getPathFromEnv(
+								QString("PGMODELER_SAMPLES_DIR"),
+								QString(SAMPLESDIR),
+								QCoreApplication::applicationDirPath() + QString("/samples")),
+	TmplConfigurationDir	= getPathFromEnv(
+								QString("PGMODELER_TMPL_CONF_DIR"),
+								QString(CONFDIR),
+								QCoreApplication::applicationDirPath() + QString("/conf")),
 
 	//Currently, plugins folder is auto-created when missing so it can't be resolved by getPathFromEnv()
-	PluginsDir=getenv("PGMODELER_PLUGINS_DIR") ? QString(getenv("PGMODELER_PLUGINS_DIR")).replace('\\','/') : QString(PLUGINSDIR),
+	PluginsDir = getenv("PGMODELER_PLUGINS_DIR")
+					? QString(getenv("PGMODELER_PLUGINS_DIR")).replace('\\','/')
+					: QString(PLUGINSDIR),
 
 #if defined(Q_OS_MAC)
-	ConfigurationsDir=getPathFromEnv(QString("PGMODELER_CONF_DIR"),
-                                      QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + QString("/%1").arg(PgModelerReverseURI)),
+	ConfigurationsDir	=getPathFromEnv(
+							QString("PGMODELER_CONF_DIR"),
+							QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)
+							+ QString("/%1").arg(PgModelerReverseURI)),
 
-	TemporaryDir=getPathFromEnv(QString("PGMODELER_TMP_DIR"),
-                                 QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)  + QString("/%1/tmp").arg(PgModelerReverseURI)),
+	TemporaryDir		=getPathFromEnv(
+							QString("PGMODELER_TMP_DIR"),
+							QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)
+							+ QString("/%1/tmp").arg(PgModelerReverseURI)),
 
 #elif defined(Q_OS_LINUX)
-	ConfigurationsDir=getPathFromEnv(QString("PGMODELER_CONF_DIR"),
-									  QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + QString("/%1").arg(PgModelerAppName)),
+	ConfigurationsDir	= getPathFromEnv(
+							QString("PGMODELER_CONF_DIR"),
+							QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)
+							+ QString("/%1").arg(PgModelerAppName)),
 
-	TemporaryDir=getPathFromEnv(QString("PGMODELER_TMP_DIR"),
-								 QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + QString("/%1/tmp").arg(PgModelerAppName)),
+	TemporaryDir		= getPathFromEnv(
+							QString("PGMODELER_TMP_DIR"),
+							QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)
+							+ QString("/%1/tmp").arg(PgModelerAppName)),
 #else
-	ConfigurationsDir=getPathFromEnv(QString("PGMODELER_CONF_DIR"),
-                                      QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) +  QString("/%1").arg(PgModelerAppName)),
+	ConfigurationsDir	= getPathFromEnv(
+							QString("PGMODELER_CONF_DIR"),
+							QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
+							+ QString("/%1").arg(PgModelerAppName)),
 
-	TemporaryDir=getPathFromEnv(QString("PGMODELER_TMP_DIR"),
-                                 QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + QString("/%1/tmp").arg(PgModelerAppName)),
+	TemporaryDir		= getPathFromEnv(
+							QString("PGMODELER_TMP_DIR"),
+							QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
+							+ QString("/%1/tmp").arg(PgModelerAppName)),
 #endif
 
-	SQLHighlightConfPath=ConfigurationsDir + DirSeparator + SQLHighlightConf + ConfigurationExt,
-	XMLHighlightConfPath=ConfigurationsDir + DirSeparator + XMLHighlightConf + ConfigurationExt,
+	SQLHighlightConfPath = ConfigurationsDir + DirSeparator + SQLHighlightConf + ConfigurationExt,
+	XMLHighlightConfPath = ConfigurationsDir + DirSeparator + XMLHighlightConf + ConfigurationExt,
 
 #if defined(Q_OS_UNIX)
 #if defined(Q_OS_MAC)
 	//For MacOSX the crash handler path is fixed (inside bundle)
-	PgModelerCHandlerPath=getPathFromEnv(QString("PGMODELER_CHANDLER_PATH"),
-										   QString(BINDIR) + QString("/pgmodeler-ch"),
-										   QString("./pgmodeler-ch")),
+	PgModelerCHandlerPath = getPathFromEnv(
+								QString("PGMODELER_CHANDLER_PATH"),
+								QString(BINDIR)							+ QString("/pgmodeler-ch"),
+								QCoreApplication::applicationDirPath()	+ QString("/pgmodeler-ch")),
 #else
-	PgModelerCHandlerPath=getPathFromEnv(QString("PGMODELER_CHANDLER_PATH"),
-										   QString(PRIVATEBINDIR) + QString("/pgmodeler-ch"),
-										   QString("./pgmodeler-ch")),
+	PgModelerCHandlerPath = getPathFromEnv(
+								QString("PGMODELER_CHANDLER_PATH"),
+								QString(PRIVATEBINDIR)					+ QString("/pgmodeler-ch"),
+								QCoreApplication::applicationDirPath()	+ QString("/pgmodeler-ch")),
 #endif
 
-	PgModelerCLIPath=getPathFromEnv(QString("PGMODELER_CLI_PATH"),
-									  QString(BINDIR) + QString("/pgmodeler-cli"),
-									  QString("./pgmodeler-cli")),
+	PgModelerCLIPath = getPathFromEnv(
+						QString("PGMODELER_CLI_PATH"),
+						QString(BINDIR)							+ QString("/pgmodeler-cli"),
+						QCoreApplication::applicationDirPath()	+ QString("/pgmodeler-cli")),
 
-	PgModelerAppPath=getPathFromEnv(QString("PGMODELER_APP_PATH"),
-									  QString(BINDIR) + QString("/pgmodeler"),
-									  QString("./pgmodeler"));
+	PgModelerAppPath = getPathFromEnv(
+						QString("PGMODELER_APP_PATH"),
+						QString(BINDIR)							+ QString("/pgmodeler"),
+						QCoreApplication::applicationDirPath()	+ QString("/pgmodeler"));
 
 
 #else
-	PgModelerCHandlerPath=getPathFromEnv(QString("PGMODELER_CHANDLER_PATH"),
-										   QString(PRIVATEBINDIR) + QString("\\pgmodeler-ch.exe"),
-										   QString(".\\pgmodeler-ch.exe")),
+	PgModelerCHandlerPath = getPathFromEnv(
+								QString("PGMODELER_CHANDLER_PATH"),
+								QString(PRIVATEBINDIR)					+ QString("\\pgmodeler-ch.exe"),
+								QCoreApplication::applicationDirPath()	+ QString("\\pgmodeler-ch.exe")),
 
-	PgModelerCLIPath=getPathFromEnv(QString("PGMODELER_CLI_PATH"),
-									  QString(PRIVATEBINDIR) + QString("\\pgmodeler-cli.exe"),
-									  QString(".\\pgmodeler-cli.exe")),
+	PgModelerCLIPath = getPathFromEnv(
+						QString("PGMODELER_CLI_PATH"),
+						QString(PRIVATEBINDIR)					+ QString("\\pgmodeler-cli.exe"),
+						QCoreApplication::applicationDirPath()	+ QString("\\pgmodeler-cli.exe")),
 
-	PgModelerAppPath=getPathFromEnv(QString("PGMODELER_APP_PATH"),
-									  QString(BINDIR) + QString("\\pgmodeler.exe"),
-									  QString(".\\pgmodeler.exe"));
+	PgModelerAppPath = getPathFromEnv(
+						QString("PGMODELER_APP_PATH"),
+						QString(BINDIR)							+ QString("\\pgmodeler.exe"),
+						QCoreApplication::applicationDirPath()	+ QString("\\pgmodeler.exe"));
 
 #endif
 

--- a/libutils/src/globalattributes.h
+++ b/libutils/src/globalattributes.h
@@ -130,7 +130,7 @@ namespace GlobalAttributes {
 
 	/*! \brief Returns the current value for an environment variable. If the current value is a path and the same does not
 	  exists then the function will return 'default_value' if it exists. Finally, if both current value and default
-	  values does not exists the the fallback value is returned even if it not exists in the filesystem */
+	  values does not exists the fallback value is returned even if it not exists in the filesystem */
 	extern QString getPathFromEnv(const QString &varname, const QString &default_val, const QString &fallback_val=QString());
 }
 

--- a/libutils/src/globalattributes.h
+++ b/libutils/src/globalattributes.h
@@ -27,111 +27,121 @@
 #ifndef GLOBAL_ATTRIBUTES_H
 #define GLOBAL_ATTRIBUTES_H
 
+#include <cstdlib>
+
 /* Including QByteArray due to 'QByteArray has no toStdString()'
    error on Qt 5.4 (Windows only) */
+#include <QApplication>
 #include <QByteArray>
-#include <cstdlib>
-#include <QString>
-#include <QDir>
 #include <QDate>
+#include <QDir>
 #include <QStandardPaths>
+#include <QString>
 
-namespace GlobalAttributes {
-	extern const QString
-	PgModelerAppName,
-	PgModelerURI,
-	PgModelerReverseURI,
-	PgModelerVersion,
-	PgModelerBuildNumber,
-	PgModelerSite,
-	PgModelerSupport,
-	PgModelerSourceURL,
-	PgModelerDownloadURL,
-	PgModelerDonateURL,
-	PgModelerUpdateCheckURL,
+class GlobalAttributes {
+	private:
+		static GlobalAttributes* _instance;
 
-	BugReportEmail,
-	BugReportFile,
-	StacktraceFile,
+		/*! \brief Returns the current value for an environment variable. If the current value is a path and the same does not
+		  exists then the function will return 'default_value' if it exists. Finally, if both current value and default
+		  values does not exists the fallback value is returned even if it not exists in the filesystem */
+		static QString getPathFromEnv(const QString &varname, const QString &default_val, const QString &fallback_val=QString());
 
-	DirSeparator,
-	DefaultConfsDir,  //! \brief Directory name which holds the default pgModeler configuration
-	ConfsBackupsDir,  //! \brief Directory name which holds the pgModeler configuration backups
-	SchemasDir,        //! \brief Default name for the schemas directory
-	SQLSchemaDir,     //! \brief Default name for the sql schemas directory
-	XMLSchemaDir,     //! \brief Default name for the xml schemas directory
-	DataDictSchemaDir,//! \brief Default name for the data dictionary schemas directory
-	AlterSchemaDir,   //! \brief Default name for the alter schemas directory
-	SchemaExt,         //! \brief Default extension for schema files
-	ObjectDTDDir,     //! \brief Default directory for dtd files
-	ObjectDTDExt,     //! \brief Default extension for dtd files
-	RootDTD,           //! \brief Root DTD of model xml files
-	MetadataDTD,				//! \brief Root DTD of objects metadata xml files
-	ConfigurationExt,  //! \brief Default extension for configuration files
-	HighlightFileSuffix, //! \brief Suffix of language highlight configuration files
+		GlobalAttributes(const QApplication& app);
 
-	CodeHighlightConf,  //! \brief Default name for the language highlight dtd
-	ObjectsStyleConf,   //! \brief Default name for the object style configuration file
-	GeneralConf,         //! \brief Default name for the general pgModeler configuration
-	ConnectionsConf,     //! \brief Default name for the DBMS connection configuration file
-	RelationshipsConf,   //! \brief Default name for the relationships configuration file
-	SnippetsConf,        //! \brief Default name for the code snippets configuration file
-	DiffPresetsConf,     //! \brief Default name for the diff presets configuration file
+	public:
+		QString
+		PgModelerVersion,
+		PgModelerAppName,
+		PgModelerURI,
+		PgModelerReverseURI,
+		PgModelerBuildNumber,
+		PgModelerSite,
+		PgModelerSupport,
+		PgModelerSourceURL,
+		PgModelerDownloadURL,
+		PgModelerDonateURL,
+		PgModelerUpdateCheckURL,
 
-	SQLHighlightConf, //! \brief Configuration file for SQL language highlight
-	XMLHighlightConf, //! \brief Configuration file for XML language highlight
-	PatternHighlightConf, //! \brief Configuration file for name patterns highlight (relationship editing form)
-	SQLHistoryConf,		//! \brief Default name for the SQL commands history configuration file
+		BugReportEmail,
+		BugReportFile,
+		StacktraceFile,
 
-	ExampleModel, //! \brief Default name for the sample model loaded on appearence configuration form
-	UiStyleConf, //! \brief Configuration file ui style
+		DirSeparator,
+		DefaultConfsDir,  //! \brief Directory name which holds the default pgModeler configuration
+		ConfsBackupsDir,  //! \brief Directory name which holds the pgModeler configuration backups
+		SchemasDir,        //! \brief Default name for the schemas directory
+		SQLSchemaDir,     //! \brief Default name for the sql schemas directory
+		XMLSchemaDir,     //! \brief Default name for the xml schemas directory
+		DataDictSchemaDir,//! \brief Default name for the data dictionary schemas directory
+		AlterSchemaDir,   //! \brief Default name for the alter schemas directory
+		SchemaExt,         //! \brief Default extension for schema files
+		ObjectDTDDir,     //! \brief Default directory for dtd files
+		ObjectDTDExt,     //! \brief Default extension for dtd files
+		RootDTD,           //! \brief Root DTD of model xml files
+		MetadataDTD,				//! \brief Root DTD of objects metadata xml files
+		ConfigurationExt,  //! \brief Default extension for configuration files
+		HighlightFileSuffix, //! \brief Suffix of language highlight configuration files
 
-	/*! \brief Fusion is the default widget style for pgModeler. User can change this by calling
-  the executable using -style option. This same style is applied to crash handler. */
-	DefaultQtStyle,
-	UiStyleOption;
+		CodeHighlightConf,  //! \brief Default name for the language highlight dtd
+		ObjectsStyleConf,   //! \brief Default name for the object style configuration file
+		GeneralConf,         //! \brief Default name for the general pgModeler configuration
+		ConnectionsConf,     //! \brief Default name for the DBMS connection configuration file
+		RelationshipsConf,   //! \brief Default name for the relationships configuration file
+		SnippetsConf,        //! \brief Default name for the code snippets configuration file
+		DiffPresetsConf,     //! \brief Default name for the diff presets configuration file
 
+		SQLHighlightConf, //! \brief Configuration file for SQL language highlight
+		XMLHighlightConf, //! \brief Configuration file for XML language highlight
+		PatternHighlightConf, //! \brief Configuration file for name patterns highlight (relationship editing form)
+		SQLHistoryConf,		//! \brief Default name for the SQL commands history configuration file
 
-	/*! \brief Environment variables used to reference the pgModeler directories.
+		ExampleModel, //! \brief Default name for the sample model loaded on appearence configuration form
+		UiStyleConf, //! \brief Configuration file ui style
 
-	 PGMODELER_SCHEMAS_DIR   --> "schemas" folder  (SQL/XML generation schema files)
-	 PGMODELER_CONF_DIR      --> "conf" folder    (user's own settings for pgModeler)
-	 PGMODELER_TMPL_CONF_DIR --> "conf" folder    (used as template settings and copied to user's settings)
-	 PGMODELER_LANG_DIR      --> "lang" folder    (ui translations)
-	 PGMODELER_PLUGINS_DIR   --> "plugins" folder (where plugins are installed)
-	 PGMODELER_TMP_DIR       --> "tmp" folder     (where temporary work are saved)
-	 PGMODELER_SAMPLES_DIR   --> "samples" folder (contains sample dbm files)
+		/*! \brief Fusion is the default widget style for pgModeler. User can change this by calling
+		the executable using -style option. This same style is applied to crash handler. */
+		DefaultQtStyle,
+		UiStyleOption;
 
-   Additional vars are used to specify where to find crash handler, command line interface
-   and main application.
+		/*! \brief Environment variables used to reference the pgModeler directories.
 
-	 PGMODELER_CHANDLER_PATH --> Full path to pgmodeler-ch executable
-	 PGMODELER_CLI_PATH      --> Full path to pgmodeler-cli executable
-	 PGMDOELER_APP_PATH      --> Full path to pgmodeler executable */
+		 PGMODELER_SCHEMAS_DIR   --> "schemas" folder  (SQL/XML generation schema files)
+		 PGMODELER_CONF_DIR      --> "conf" folder    (user's own settings for pgModeler)
+		 PGMODELER_TMPL_CONF_DIR --> "conf" folder    (used as template settings and copied to user's settings)
+		 PGMODELER_LANG_DIR      --> "lang" folder    (ui translations)
+		 PGMODELER_PLUGINS_DIR   --> "plugins" folder (where plugins are installed)
+		 PGMODELER_TMP_DIR       --> "tmp" folder     (where temporary work are saved)
+		 PGMODELER_SAMPLES_DIR   --> "samples" folder (contains sample dbm files)
 
-	extern const QString
-	SchemasRootDir,
-	LanguagesDir,
-	PluginsDir,
-	TemporaryDir,
-	SamplesDir,
-	TmplConfigurationDir,
-	ConfigurationsDir,
-	SQLHighlightConfPath,
-	XMLHighlightConfPath,
-	PgModelerCHandlerPath,
-	PgModelerCLIPath,
-	PgModelerAppPath;
+		Additional vars are used to specify where to find crash handler, command line interface
+		and main application.
 
-#ifdef DEMO_VERSION
-	//Maximum object creation counter for demo version
-	extern const unsigned MaxObjectCount;
-#endif
+		 PGMODELER_CHANDLER_PATH --> Full path to pgmodeler-ch executable
+		 PGMODELER_CLI_PATH      --> Full path to pgmodeler-cli executable
+		 PGMDOELER_APP_PATH      --> Full path to pgmodeler executable */
 
-	/*! \brief Returns the current value for an environment variable. If the current value is a path and the same does not
-	  exists then the function will return 'default_value' if it exists. Finally, if both current value and default
-	  values does not exists the fallback value is returned even if it not exists in the filesystem */
-	extern QString getPathFromEnv(const QString &varname, const QString &default_val, const QString &fallback_val=QString());
-}
+		QString
+		SchemasRootDir,
+		LanguagesDir,
+		SamplesDir,
+		TmplConfigurationDir,
+		PluginsDir,
+		ConfigurationsDir,
+		TemporaryDir,
+		SQLHighlightConfPath,
+		XMLHighlightConfPath,
+		PgModelerCHandlerPath,
+		PgModelerCLIPath,
+		PgModelerAppPath;
+
+	#ifdef DEMO_VERSION
+		//Maximum object creation counter for demo version
+		unsigned MaxObjectCount;
+	#endif
+
+		static GlobalAttributes& create(const QApplication& app);
+		static const GlobalAttributes& get();
+};
 
 #endif

--- a/main-cli/src/main.cpp
+++ b/main-cli/src/main.cpp
@@ -25,7 +25,7 @@ int main(int argc, char **argv)
 
 #ifdef DEMO_VERSION
 	out << endl;
-	out << QString("pgModeler ") << GlobalAttributes::PgModelerVersion << QT_TR_NOOP(" command line interface.") << endl;
+	out << QString("pgModeler ") << GlobalAttributes::get().PgModelerVersion << QT_TR_NOOP(" command line interface.") << endl;
 	out << QT_TR_NOOP("PostgreSQL Database Modeler Project - pgmodeler.io") << endl;
 	out << QT_TR_NOOP("Copyright 2006-2019 Raphael A. Silva <raphael@pgmodeler.io>") << endl;
 	out << QT_TR_NOOP("\n** CLI disabled in demonstration version! **") << endl << endl;
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
 		PgModelerCli pgmodeler_cli(argc, argv);
 
 		//Tries to load the ui translation according to the system's locale
-		translator.load(QLocale::system().name(), GlobalAttributes::LanguagesDir);
+		translator.load(QLocale::system().name(), GlobalAttributes::get().LanguagesDir);
 
 		//Installs the translator on the application
 		pgmodeler_cli.installTranslator(&translator);

--- a/main-cli/src/pgmodelercli.cpp
+++ b/main-cli/src/pgmodelercli.cpp
@@ -375,7 +375,7 @@ bool PgModelerCli::isOptionRecognized(QString &op, bool &accepts_val)
 void PgModelerCli::showMenu(void)
 {
 	out << endl;
-	out << QString("pgModeler ") << GlobalAttributes::PgModelerVersion << trUtf8(" command line interface.") << endl;
+	out << QString("pgModeler ") << GlobalAttributes::get().PgModelerVersion << trUtf8(" command line interface.") << endl;
 	out << trUtf8("PostgreSQL Database Modeler Project - pgmodeler.io") << endl;
 	out << trUtf8("Copyright 2006-2018 Raphael A. Silva <raphael@pgmodeler.io>") << endl;
 	out << endl;
@@ -400,7 +400,7 @@ void PgModelerCli::showMenu(void)
 	out << trUtf8("  %1, %2\t\t\t    Show this help menu.").arg(short_opts[Help]).arg(Help) << endl;
 	out << endl;
 	out << trUtf8("Connection options: ") << endl;
-	out << trUtf8("  %1, %2\t\t    List available connections in file %3.").arg(short_opts[ListConns]).arg(ListConns).arg(GlobalAttributes::ConnectionsConf + GlobalAttributes::ConfigurationExt) << endl;
+	out << trUtf8("  %1, %2\t\t    List available connections in file %3.").arg(short_opts[ListConns]).arg(ListConns).arg(GlobalAttributes::get().ConnectionsConf + GlobalAttributes::get().ConfigurationExt) << endl;
 	out << trUtf8("  %1, %2 [ALIAS]\t    Connection configuration alias to be used.").arg(short_opts[ConnAlias]).arg(ConnAlias) << endl;
 	out << trUtf8("  %1, %2 [HOST]\t\t    PostgreSQL host in which a task will operate.").arg(short_opts[Host]).arg(Host) << endl;
 	out << trUtf8("  %1, %2 [PORT]\t\t    PostgreSQL host listening port.").arg(short_opts[Port]).arg(Port) << endl;
@@ -526,13 +526,13 @@ void PgModelerCli::parseOptions(attribs_map &opts)
 
 		if(other_modes_cnt==0 && mode_cnt==0)
 			throw Exception(trUtf8("No operation mode was specified!"), ErrorCode::Custom,__PRETTY_FUNCTION__,__FILE__,__LINE__);
-		
+
 		if((mode_cnt > 0 && (fix_model || upd_mime || import_db || diff)) || (mode_cnt==0 && other_modes_cnt > 1))
 			throw Exception(trUtf8("Export, fix model, import database, diff and update mime operations can't be used at the same time!"), ErrorCode::Custom,__PRETTY_FUNCTION__,__FILE__,__LINE__);
-		
+
 		if(!fix_model && !upd_mime && mode_cnt > 1)
 			throw Exception(trUtf8("Multiple export mode was specified!"), ErrorCode::Custom,__PRETTY_FUNCTION__,__FILE__,__LINE__);
-		
+
 		if(!upd_mime && !import_db && !diff && opts[Input].isEmpty())
 			throw Exception(trUtf8("No input file was specified!"), ErrorCode::Custom,__PRETTY_FUNCTION__,__FILE__,__LINE__);
 
@@ -541,22 +541,22 @@ void PgModelerCli::parseOptions(attribs_map &opts)
 
 		if(!opts.count(ExportToDbms) && !upd_mime && !diff && opts[Output].isEmpty())
 			throw Exception(trUtf8("No output file was specified!"), ErrorCode::Custom,__PRETTY_FUNCTION__,__FILE__,__LINE__);
-		
+
 		if(!opts.count(ExportToDbms) && !upd_mime && !import_db &&
 			 !opts[Input].isEmpty() && !opts[Output].isEmpty() &&
 			 QFileInfo(opts[Input]).absoluteFilePath() == QFileInfo(opts[Output]).absoluteFilePath())
 			throw Exception(trUtf8("Input file must be different from output!"), ErrorCode::Custom,__PRETTY_FUNCTION__,__FILE__,__LINE__);
-		
+
 		if(opts.count(ExportToDbms) && !opts.count(ConnAlias) &&
 			 (!opts.count(Host) || !opts.count(User) || !opts.count(Passwd) || !opts.count(InitialDb)) )
 			throw Exception(trUtf8("Incomplete connection information!"), ErrorCode::Custom,__PRETTY_FUNCTION__,__FILE__,__LINE__);
-		
+
 		if(opts.count(ExportToPng) && (zoom < ModelWidget::MinimumZoom || zoom > ModelWidget::MaximumZoom))
 			throw Exception(trUtf8("Invalid zoom specified!"), ErrorCode::Custom,__PRETTY_FUNCTION__,__FILE__,__LINE__);
-		
+
 		if(upd_mime && opts[DbmMimeType]!=Install && opts[DbmMimeType]!=Uninstall)
 			throw Exception(trUtf8("Invalid action specified to update mime option!"), ErrorCode::Custom,__PRETTY_FUNCTION__,__FILE__,__LINE__);
-			
+
 		if(opts.count(Diff))
 		{
 			if(opts[Input].isEmpty() && opts[InputDb].isEmpty())
@@ -574,7 +574,7 @@ void PgModelerCli::parseOptions(attribs_map &opts)
 			if(opts.count(SaveDiff) && opts[Output].isEmpty())
 				throw Exception(trUtf8("No output file for the diff code was specified!"), ErrorCode::Custom,__PRETTY_FUNCTION__,__FILE__,__LINE__);
 		}
-		
+
 		//Converting input and output files to absolute paths to avoid that they are read/written on the app's working dir
 		if(!opts[Input].isEmpty())
 			opts[Input]=QFileInfo(opts[Input]).absoluteFilePath();
@@ -592,7 +592,7 @@ int PgModelerCli::exec(void)
 	{
 		if(!parsed_opts.empty())
 		{
-			printMessage(QString("\npgModeler %1 %2").arg(GlobalAttributes::PgModelerVersion).arg(trUtf8("command line interface.")));
+			printMessage(QString("\npgModeler %1 %2").arg(GlobalAttributes::get().PgModelerVersion).arg(trUtf8("command line interface.")));
 
 			if(parsed_opts.count(FixModel))
 				fixModel();
@@ -1613,12 +1613,12 @@ void PgModelerCli::handleMimeDatabase(bool uninstall)
 	QString str_aux,
 
 			//Configures the path to the application logo
-			exec_icon=QDir(GlobalAttributes::TmplConfigurationDir +
-						   GlobalAttributes::DirSeparator + QString("pgmodeler_logo.png")).absolutePath(),
+			exec_icon=QDir(GlobalAttributes::get().TmplConfigurationDir +
+						   GlobalAttributes::get().DirSeparator + QString("pgmodeler_logo.png")).absolutePath(),
 
 			//Configures the path to the document logo
-			dbm_icon=QDir(GlobalAttributes::TmplConfigurationDir +
-						  GlobalAttributes::DirSeparator + QString("pgmodeler_dbm.png")).absolutePath(),
+			dbm_icon=QDir(GlobalAttributes::get().TmplConfigurationDir +
+						  GlobalAttributes::get().DirSeparator + QString("pgmodeler_dbm.png")).absolutePath(),
 
 			//Path to directory that register mime types
 			mime_db_dir=QDir::homePath() + QString("/.local/share/mime"),
@@ -1626,15 +1626,15 @@ void PgModelerCli::handleMimeDatabase(bool uninstall)
 			//Path to the file that associates apps to mimetypes
 			mimeapps=QDir::homePath() + QString("/.local/share/applications/mimeapps.list"),
 
-			base_conf_dir=GlobalAttributes::TmplConfigurationDir + GlobalAttributes::DirSeparator +
-						  GlobalAttributes::SchemasDir + GlobalAttributes::DirSeparator,
+			base_conf_dir=GlobalAttributes::get().TmplConfigurationDir + GlobalAttributes::get().DirSeparator +
+						  GlobalAttributes::get().SchemasDir + GlobalAttributes::get().DirSeparator,
 
 			//Files generated after update file association (application-dbm.xml and pgModeler.desktop)
 			files[] = { QDir::homePath() + QString("/.local/share/applications/pgModeler.desktop"),
 						mime_db_dir + QString("/packages/application-dbm.xml") },
 
-			schemas[] = { base_conf_dir + QString("desktop") + GlobalAttributes::SchemaExt,
-						  base_conf_dir + QString("application-dbm") + GlobalAttributes::SchemaExt };
+			schemas[] = { base_conf_dir + QString("desktop") + GlobalAttributes::get().SchemaExt,
+						  base_conf_dir + QString("application-dbm") + GlobalAttributes::get().SchemaExt };
 	QByteArray buf, buf_aux;
 	QFile out;
 
@@ -1650,11 +1650,11 @@ void PgModelerCli::handleMimeDatabase(bool uninstall)
 	else if(!uninstall)
 	{
 		QString startup_script=QString("%1/start-pgmodeler.sh")
-							   .arg(QFileInfo(GlobalAttributes::PgModelerAppPath).absolutePath());
+							   .arg(QFileInfo(GlobalAttributes::get().PgModelerAppPath).absolutePath());
 
 		attribs[Attributes::WorkingDir]=QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
 		attribs[Attributes::Application]=(QFileInfo(startup_script).exists() ?
-													 startup_script : GlobalAttributes::PgModelerAppPath);
+													 startup_script : GlobalAttributes::get().PgModelerAppPath);
 		attribs[Attributes::Icon]=exec_icon;
 	}
 
@@ -1753,7 +1753,7 @@ void PgModelerCli::handleMimeDatabase(bool uninstall)
 
 	//Checking if the .dbm registry key exists
 	QSettings dbm_ext(QString("HKEY_CURRENT_USER\\Software\\Classes\\.dbm"), QSettings::NativeFormat);
-    QString exe_path=QDir::toNativeSeparators(GlobalAttributes::PgModelerAppPath);
+    QString exe_path=QDir::toNativeSeparators(GlobalAttributes::get().PgModelerAppPath);
 
 	//If there is no value assigned to .dbm/Default key and the user wants to uninstall file association, raises an error
 	if(uninstall && dbm_ext.value(QString("Default")).toString().isEmpty())

--- a/main/src/application.cpp
+++ b/main/src/application.cpp
@@ -36,9 +36,6 @@ Application::Application(int &argc, char **argv) : QApplication(argc,argv)
 	//Creating the initial user's configuration
 	createUserConfiguration();
 
-	//Changing the current working dir to the executable's directory in
-	QDir::setCurrent(this->applicationDirPath());
-
 	//Adding paths which executable will find plugins and it's dependecies
 	this->addLibraryPath(this->applicationDirPath());
 

--- a/main/src/application.cpp
+++ b/main/src/application.cpp
@@ -23,7 +23,7 @@
 Application::Application(int &argc, char **argv) : QApplication(argc,argv)
 {
 	QTranslator *main_translator=nullptr, *plugin_translator=nullptr;
-	GlobalAttributes::get().create(*this);
+	GlobalAttributes::create(*this);
 
 	QFile ui_style(GlobalAttributes::get().TmplConfigurationDir +
 				   GlobalAttributes::get().DirSeparator +

--- a/main/src/application.cpp
+++ b/main/src/application.cpp
@@ -23,10 +23,12 @@
 Application::Application(int &argc, char **argv) : QApplication(argc,argv)
 {
 	QTranslator *main_translator=nullptr, *plugin_translator=nullptr;
-	QFile ui_style(GlobalAttributes::TmplConfigurationDir +
-				   GlobalAttributes::DirSeparator +
-				   GlobalAttributes::UiStyleConf +
-				   GlobalAttributes::ConfigurationExt);
+	GlobalAttributes::get().create(*this);
+
+	QFile ui_style(GlobalAttributes::get().TmplConfigurationDir +
+				   GlobalAttributes::get().DirSeparator +
+				   GlobalAttributes::get().UiStyleConf +
+				   GlobalAttributes::get().ConfigurationExt);
 	QString plugin_name, plug_lang_dir, plug_lang_file;
 	QStringList dir_list;
 	QDir dir;
@@ -41,25 +43,25 @@ Application::Application(int &argc, char **argv) : QApplication(argc,argv)
 	this->addLibraryPath(this->applicationDirPath());
 
 	//If pgModeler bundles plugins, add the root plugins path to lib search paths
-	if(dir.exists(GlobalAttributes::PluginsDir))
-		this->addLibraryPath(GlobalAttributes::PluginsDir);
+	if(dir.exists(GlobalAttributes::get().PluginsDir))
+		this->addLibraryPath(GlobalAttributes::get().PluginsDir);
 
 	//Check if the temporary dir exists, if not, creates it.
-	if(!dir.exists(GlobalAttributes::TemporaryDir))
+	if(!dir.exists(GlobalAttributes::get().TemporaryDir))
 	{
-		if(!dir.mkdir(GlobalAttributes::TemporaryDir))
+		if(!dir.mkdir(GlobalAttributes::get().TemporaryDir))
 		{
 			Messagebox msg;
-			msg.show(Exception(Exception::getErrorMessage(ErrorCode::FileDirectoryNotWritten).arg(GlobalAttributes::TemporaryDir),
+			msg.show(Exception(Exception::getErrorMessage(ErrorCode::FileDirectoryNotWritten).arg(GlobalAttributes::get().TemporaryDir),
 												 ErrorCode::FileDirectoryNotWritten, __PRETTY_FUNCTION__,__FILE__,__LINE__));
 		}
 	}
 
 	//Trying to identify if the user defined a custom UI language in the pgmodeler.conf file
-	QString conf_file =	GlobalAttributes::ConfigurationsDir +
-											GlobalAttributes::DirSeparator +
-											GlobalAttributes::GeneralConf +
-											GlobalAttributes::ConfigurationExt;
+	QString conf_file =	GlobalAttributes::get().ConfigurationsDir +
+											GlobalAttributes::get().DirSeparator +
+											GlobalAttributes::get().GeneralConf +
+											GlobalAttributes::get().ConfigurationExt;
 	QFile input;
 	QString lang_id = QLocale::system().name();
 
@@ -79,12 +81,12 @@ Application::Application(int &argc, char **argv) : QApplication(argc,argv)
 
 	//Tries to load the main ui translation according to the system's locale
 	main_translator=new QTranslator(this);
-	main_translator->load(lang_id, GlobalAttributes::LanguagesDir);
+	main_translator->load(lang_id, GlobalAttributes::get().LanguagesDir);
 	this->installTranslator(main_translator);
 
 	//Trying to load plugins translations
-	dir_list=QDir(GlobalAttributes::PluginsDir +
-								GlobalAttributes::DirSeparator,
+	dir_list=QDir(GlobalAttributes::get().PluginsDir +
+								GlobalAttributes::get().DirSeparator,
 								QString("*"), QDir::Name, QDir::AllDirs | QDir::NoDotAndDotDot).entryList();
 
 	while(!dir_list.isEmpty())
@@ -93,10 +95,10 @@ Application::Application(int &argc, char **argv) : QApplication(argc,argv)
 		dir_list.pop_front();
 
 		//Configure the path to "lang" subdir at current plugin directory
-		plug_lang_dir=GlobalAttributes::PluginsDir +
-					  GlobalAttributes::DirSeparator + plugin_name +
-					  GlobalAttributes::DirSeparator + QString("lang") +
-					  GlobalAttributes::DirSeparator;
+		plug_lang_dir=GlobalAttributes::get().PluginsDir +
+					  GlobalAttributes::get().DirSeparator + plugin_name +
+					  GlobalAttributes::get().DirSeparator + QString("lang") +
+					  GlobalAttributes::get().DirSeparator;
 
 		plug_lang_file=plugin_name + QString(".") + lang_id;
 
@@ -145,20 +147,20 @@ bool Application::notify(QObject *receiver, QEvent *event)
 
 void Application::createUserConfiguration(void)
 {
-	QDir config_dir(GlobalAttributes::ConfigurationsDir);
+	QDir config_dir(GlobalAttributes::get().ConfigurationsDir);
 
 	try
 	{
 		//If the directory not exists or is empty
 		if(!config_dir.exists() ||
-				config_dir.entryList({QString("*%1").arg(GlobalAttributes::ConfigurationExt)},
+				config_dir.entryList({QString("*%1").arg(GlobalAttributes::get().ConfigurationExt)},
 									 QDir::Files | QDir::NoDotAndDotDot).isEmpty())
-			copyFilesRecursively(GlobalAttributes::TmplConfigurationDir, GlobalAttributes::ConfigurationsDir);
+			copyFilesRecursively(GlobalAttributes::get().TmplConfigurationDir, GlobalAttributes::get().ConfigurationsDir);
 	}
 	catch(Exception &e)
 	{
 		Messagebox msg_box;
-		msg_box.show(e, trUtf8("Failed to create initial configuration in `%1'! Check if the current user has write permission over that path and at least read permission over `%2'.").arg(GlobalAttributes::ConfigurationsDir, CONFDIR));
+		msg_box.show(e, trUtf8("Failed to create initial configuration in `%1'! Check if the current user has write permission over that path and at least read permission over `%2'.").arg(GlobalAttributes::get().ConfigurationsDir, CONFDIR));
 		throw Exception(e.getErrorMessage(),e.getErrorCode(),__PRETTY_FUNCTION__,__FILE__,__LINE__,&e);
 	}
 }
@@ -182,13 +184,13 @@ void Application::copyFilesRecursively(const QString &src_path, const QString &d
 			throw Exception(Exception::getErrorMessage(ErrorCode::FileDirectoryNotWritten).arg(dst_path),
 							__PRETTY_FUNCTION__,__FILE__,__LINE__);
 
-		filenames = src_dir.entryList({QString("*%1").arg(GlobalAttributes::ConfigurationExt)},
+		filenames = src_dir.entryList({QString("*%1").arg(GlobalAttributes::get().ConfigurationExt)},
 									  QDir::Files | QDir::NoDotAndDotDot);
 
 		for(QString filename : filenames)
 		{
 			//Avoiding the copy of ui-style.conf file
-			if(!filename.contains(GlobalAttributes::UiStyleConf))
+			if(!filename.contains(GlobalAttributes::get().UiStyleConf))
 			{
 				new_src_path = src_path + src_dir.separator() + filename;
 				new_dst_path = dst_path + dst_dir.separator() + filename;

--- a/main/src/application.h
+++ b/main/src/application.h
@@ -36,9 +36,9 @@
 #define APPLICATION_H
 
 #include <QApplication>
+#include <QFile>
 #include <QTextStream>
 #include <QTranslator>
-#include <QFile>
 
 class Application: public QApplication {
 	private:

--- a/main/src/main.cpp
+++ b/main/src/main.cpp
@@ -38,12 +38,12 @@ void startCrashHandler(int signal)
 	symbols = backtrace_symbols(stack, stack_size);
 #endif
 
-	cmd=QString("\"%1\"").arg(GlobalAttributes::PgModelerCHandlerPath) + QString(" -style ") + GlobalAttributes::DefaultQtStyle;
+	cmd=QString("\"%1\"").arg(GlobalAttributes::get().PgModelerCHandlerPath) + QString(" -style ") + GlobalAttributes::get().DefaultQtStyle;
 
 	//Creates the stacktrace file
-	output.setFileName(GlobalAttributes::TemporaryDir +
-					   GlobalAttributes::DirSeparator +
-					   GlobalAttributes::StacktraceFile);
+	output.setFileName(GlobalAttributes::get().TemporaryDir +
+					   GlobalAttributes::get().DirSeparator +
+					   GlobalAttributes::get().StacktraceFile);
 	output.open(QFile::WriteOnly);
 
 	if(output.isOpen())
@@ -51,8 +51,8 @@ void startCrashHandler(int signal)
 		lin=QString("** pgModeler crashed after receive signal: %1 **\n\nDate/Time: %2 \nVersion: %3 \nBuild: %4 \n")
 			.arg(signal)
 			.arg(QDateTime::currentDateTime().toString(QString("yyyy-MM-dd hh:mm:ss")))
-			.arg(GlobalAttributes::PgModelerVersion)
-			.arg(GlobalAttributes::PgModelerBuildNumber);
+			.arg(GlobalAttributes::get().PgModelerVersion)
+			.arg(GlobalAttributes::get().PgModelerBuildNumber);
 
 		lin+=QString("Compilation Qt version: %1\nRunning Qt version: %2\n\n")
 			 .arg(QT_VERSION_STR)
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
 
 		//If no custom style is specified we force the usage of Fusion (the default for Qt and pgModeler)
 		if(!using_style)
-			app.setStyle(GlobalAttributes::DefaultQtStyle);
+			app.setStyle(GlobalAttributes::get().DefaultQtStyle);
 
 		//Loading the application splash screen
 		QSplashScreen splash;

--- a/tests/src/databasemodeltest/databasemodeltest.cpp
+++ b/tests/src/databasemodeltest/databasemodeltest.cpp
@@ -32,8 +32,8 @@ void DatabaseModelTest::saveObjectsMetadata(void)
 {
 	DatabaseModel dbmodel;
 	QTextStream out(stdout);
-	QString output=QFileInfo(BINDIR).absolutePath() + GlobalAttributes::DirSeparator + QString("demo.omf"),
-			input=SAMPLESDIR + GlobalAttributes::DirSeparator + QString("demo.dbm");
+	QString output=QFileInfo(BINDIR).absolutePath() + GlobalAttributes::get().DirSeparator + QString("demo.omf"),
+			input=SAMPLESDIR + GlobalAttributes::get().DirSeparator + QString("demo.dbm");
 
 	try
 	{
@@ -55,9 +55,9 @@ void DatabaseModelTest::loadObjectsMetadata(void)
 {
 	DatabaseModel dbmodel;
 	QTextStream out(stdout);
-	QString input_opf=QFileInfo(BINDIR).absolutePath() + GlobalAttributes::DirSeparator + QString("demo.omf"),
-			input_dbm=SAMPLESDIR + GlobalAttributes::DirSeparator + QString("demo.dbm"),
-			output=QFileInfo(BINDIR).absolutePath() + GlobalAttributes::DirSeparator + QString("demo_changed.dbm");
+	QString input_opf=QFileInfo(BINDIR).absolutePath() + GlobalAttributes::get().DirSeparator + QString("demo.omf"),
+			input_dbm=SAMPLESDIR + GlobalAttributes::get().DirSeparator + QString("demo.dbm"),
+			output=QFileInfo(BINDIR).absolutePath() + GlobalAttributes::get().DirSeparator + QString("demo_changed.dbm");
 
 	try
 	{

--- a/tests/src/syntaxhighlightertest/syntaxhighlightertest.cpp
+++ b/tests/src/syntaxhighlightertest/syntaxhighlightertest.cpp
@@ -35,7 +35,7 @@ void SyntaxHighlighterTest::handleMultiLineComment(void)
   SyntaxHighlighter *sql_hl=nullptr;
 
   sql_hl=new SyntaxHighlighter(edt, false);
-  sql_hl->loadConfiguration(GlobalAttributes::SQLHighlightConfPath);
+  sql_hl->loadConfiguration(GlobalAttributes::get().SQLHighlightConfPath);
 
   layout->addWidget(edt);
   dlg->exec();

--- a/windeploy.sh
+++ b/windeploy.sh
@@ -3,7 +3,7 @@
 LOG=windeploy.log
 
 # Detecting current pgModeler version
-DEPLOY_VER=`cat libutils/src/globalattributes.cpp | grep PgModelerVersion | sed 's/PgModelerVersion=QString("//g' | sed 's/")//g'`
+DEPLOY_VER=`cat libutils/src/globalattributes.cpp | grep PgModelerVersion | sed 's/PgModelerVersion(QString("//g' | sed 's/")//g'`
 DEPLOY_VER=${DEPLOY_VER/PGMODELER_VERSION=\"/}
 DEPLOY_VER=`echo ${DEPLOY_VER/\",/} | tr -d ' '`
 


### PR DESCRIPTION
PR #1369 for #1368 didn't work upstream and make sense to not work, because `QApplication` is needed too early in the process of starting up the app.

So I suggest an alternative implementation using a singleton which is created once AFTER the app started up and can then use `QApplication` to retrieve data as necessary. Changing the formerly used namespace to a class implementing a singleton requires the least amount of changes and allows more control over what gets created when how, especially with an instance of `QApplication` being available.

Don't get confused by the many changes: What has formerly been a constant in a namespace and got a value set, is now simply changed to an instance variable of some class and gets a value set as well in the member initialization of the CTOR of the class. Syntax is very similar, it's only `SomeVar = SomeVal` vs. `SomeVar(SomeVal)` mostly. Most other changes are using the new class instead of the namespace: `GlobalAttributes::SomeVar` vs. `GlobalAttributes::get().SomeVar`.

The singleton is only used as PoC, that can be reconsidered and I don't care much about the number of instances of `GlobalAttributes` being available. The important thing is in my opinion switching `GlobalAttributes` to a class so that one has more control over when those attributes get created.

While things compile successfully and using Process Monitor it seems that some necessary paths are read successfully this way, the app still crashes:

> Exception code=0xc00000fd flags=0x0 at 0x000000006E5C3BC4

Don't know how to debug this further easily currently and would like to discuss if this is an approach @rkhaotix wants to follow at all or not.