### PR TITLE
updateSceneLayers() when we undo/redo

### DIFF
--- a/libs/libgui/src/widgets/operationlistwidget.cpp
+++ b/libs/libgui/src/widgets/operationlistwidget.cpp
@@ -157,6 +157,7 @@ void OperationListWidget::undoOperation()
 		model_wgt->op_list->undoOperation();
 		notifyUpdateOnModel();
 		model_wgt->scene->clearSelection();
+		model_wgt->updateSceneLayers();
 		QApplication::restoreOverrideCursor();
 	}
 	catch(Exception &e)
@@ -182,6 +183,7 @@ void OperationListWidget::redoOperation()
 		model_wgt->op_list->redoOperation();
 		notifyUpdateOnModel();
 		model_wgt->scene->clearSelection();
+		model_wgt->updateSceneLayers();
 		QApplication::restoreOverrideCursor();
 	}
 	catch(Exception &e)


### PR DESCRIPTION
I noticed that when the scene was moved while "display layer rectangles" was enabled and that move was then undone, the layer rectangles would stay in place. This patch fixes that issue.