### PR TITLE
Set RW permissions when copying config file with RO.

### DIFF
--- a/libs/libgui/src/settings/baseconfigwidget.cpp
+++ b/libs/libgui/src/settings/baseconfigwidget.cpp
@@ -116,6 +116,13 @@ void BaseConfigWidget::restoreDefaults(const QString &conf_id, bool silent)
 		bkp_saved = QFile::rename(current_file, bkp_filename);
 		QFile::copy(default_file, current_file);
 
+		// Set write permissions when copying file with read-only permissions
+		QFile qconfig(current_file);
+		if (!(qconfig.permissions() & QFileDevice::WriteOwner))
+		{
+			qconfig.setPermissions(qconfig.permissions() | QFileDevice::WriteOwner);
+		}
+
 		if(bkp_saved && !silent)
 		{
 			Messagebox msg_box;

--- a/libs/libutils/src/application.cpp
+++ b/libs/libutils/src/application.cpp
@@ -83,7 +83,18 @@ void Application::copyFilesRecursively(const QString &src_path, const QString &d
 	else
 	{
 		if(!QFile::copy(src_path, dst_path))
+		{
 			throw Exception(Exception::getErrorMessage(ErrorCode::FileDirectoryNotWritten).arg(dst_path),
 											__PRETTY_FUNCTION__,__FILE__,__LINE__);
+		}
+		else
+		{
+			// Set write permissions when copying file with read-only permissions
+			QFile qconfig(dst_path);
+			if (!(qconfig.permissions() & QFileDevice::WriteOwner))
+			{
+				qconfig.setPermissions(qconfig.permissions() | QFileDevice::WriteOwner);
+			}
+		}
 	}
 }


### PR DESCRIPTION
In package managers such as Nix, application files are stored without write permissions and as a result when copying a default configuration file, the permissions of the file are also kept and as a result pgModeler cannot save the settings.

This PR fixes the following error:
```
Unable to write the file /home/elxreno/.config/pgmodeler/pgmodeler.conf due to one or more errors in the definition generation process!
```