### PR TITLE
Added support for new libicui versions

### DIFF
--- a/linuxdeploy.sh
+++ b/linuxdeploy.sh
@@ -182,9 +182,9 @@ else
            libQt5Core.so.5 \
            libQt5XcbQpa.so.5 \
            libQt5Svg.so.5 \
-           libicui18n.so.5* \
-           libicuuc.so.5* \
-           libicudata.so.5*"
+           libicui18n.so.* \
+           libicuuc.so.* \
+           libicudata.so.*"
 fi
 
 clear 


### PR DESCRIPTION
The latest version of Ubuntu (21.04) uses the 6X version of libicu. Updated linuxdeploy.sh to relax the version restriction in the library copy glob, so new versions of Ubuntu can be supported.