### PR TITLE
Add $$QMAKE_LIBS_EXECINFO

### DIFF
--- a/apps/pgmodeler/pgmodeler.pro
+++ b/apps/pgmodeler/pgmodeler.pro
@@ -17,7 +17,8 @@ unix|windows: LIBS += $$LIBGUI_LIB \
 		      $$LIBCONNECTOR_LIB \
 		      $$LIBCORE_LIB \
 		      $$LIBPARSERS_LIB \
-		      $$LIBUTILS_LIB
+		      $$LIBUTILS_LIB \
+		      $$QMAKE_LIBS_EXECINFO
 
 INCLUDEPATH += $$LIBGUI_INC \
 	       $$LIBCANVAS_INC \


### PR DESCRIPTION
Unbreak build on FreeBSD (and other BSD I think so).

$$QMAKE_LIBS_EXECINFO will add -lexecinfo if required