### PR TITLE
Another fix for Unix build

### DIFF
--- a/pgmodeler.pri
+++ b/pgmodeler.pri
@@ -81,8 +81,8 @@ DEFINES+=BUILDDATE=\\\"$${BUILDDATE}\\\"
 # The values of each variable changes between supported platforms and are describe as follow
 
 
-# Linux custom variables settings
-linux {
+# UNIX custom variables settings
+unix:!macx {
   CONFIG += x11
 
   # If the AppImage generation option is set


### PR DESCRIPTION
You can replace linux by unix (except for mac I guess).

I patch it like this on [FreeBSD](https://github.com/freebsd/freebsd-ports/blob/84003150fa4ae3dd78053701912d1f7b4e8bc4b8/databases/pgmodeler/Makefile#L28)