### PR TITLE
Add CodeOption to Split File Script Export.  Allow create all scripts with Children.

### DIFF
--- a/apps/pgmodeler-cli/src/pgmodelercliapp.h
+++ b/apps/pgmodeler-cli/src/pgmodelercliapp.h
@@ -160,6 +160,7 @@ class PgModelerCliApp: public Application {
 		SystemWide,
 		NoIndex,
 		Split,
+		CodeOption,
 
 		IgnoreImportErrors,
 		ImportSystemObjs,

--- a/libs/libcore/src/databasemodel.h
+++ b/libs/libcore/src/databasemodel.h
@@ -70,6 +70,10 @@ class DatabaseModel:  public QObject, public BaseObject {
 	private:
 		Q_OBJECT
 
+		static constexpr unsigned OriginalSql=0,
+		DependenciesSql=1,
+		ChildrenSql=2;
+
 		/*! \brief Stores all changes performed in the database model
 		 * The only purpose of this structure is to be used by the partial diff to filter certain objects by operation/date and,
 		 * differently from OperationList class, it's data persisted in the database model file. */
@@ -477,7 +481,7 @@ class DatabaseModel:  public QObject, public BaseObject {
 		/*! \brief Saves the model's SQL code definition by creating separated files for each object
 		 * The provided path must be a directory. If it does not exists then the method will create
 		 * it prior to the generation of the files. */
-		void saveSplitSQLDefinition(const QString &path);
+		void saveSplitSQLDefinition(const QString &path, unsigned code_option = OriginalSql);
 
 		/*! \brief Returns the complete SQL/XML defintion for the entire model (including all the other objects).
 		 The parameter 'export_file' is used to format the generated code in a way that can be saved

--- a/libs/libgui/src/tools/modelexporthelper.cpp
+++ b/libs/libgui/src/tools/modelexporthelper.cpp
@@ -59,7 +59,7 @@ void ModelExportHelper::setIgnoredErrors(const QStringList &err_codes)
 	}
 }
 
-void ModelExportHelper::exportToSQL(DatabaseModel *db_model, const QString &filename, const QString &pgsql_ver, bool split)
+void ModelExportHelper::exportToSQL(DatabaseModel *db_model, const QString &filename, const QString &pgsql_ver, bool split, unsigned code_option)
 {
 	if(!db_model)
 		throw Exception(ErrorCode::AsgNotAllocattedObject,__PRETTY_FUNCTION__,__FILE__,__LINE__);
@@ -82,7 +82,7 @@ void ModelExportHelper::exportToSQL(DatabaseModel *db_model, const QString &file
 		}
 		else
 		{
-			db_model->saveSplitSQLDefinition(filename);
+			db_model->saveSplitSQLDefinition(filename, code_option);
 			emit s_progressUpdated(100, tr("SQL files successfully written in `%1'.").arg(filename), ObjectType::BaseObject);
 		}
 

--- a/libs/libgui/src/tools/modelexporthelper.h
+++ b/libs/libgui/src/tools/modelexporthelper.h
@@ -157,7 +157,7 @@ class ModelExportHelper: public QObject {
 		void setIgnoredErrors(const QStringList &err_codes);
 
 		//! \brief Exports the model to a named SQL file. The PostgreSQL version syntax must be specified.
-		void exportToSQL(DatabaseModel *db_model, const QString &filename, const QString &pgsql_ver, bool split);
+		void exportToSQL(DatabaseModel *db_model, const QString &filename, const QString &pgsql_ver, bool split, unsigned code_option=0);
 
 		/*! \brief Exports the model to a named PNG image. The boolean parameters controls the grid exhibition
 		as well the page delimiters on the output image. The zoom parameter controls the zoom applied to the viewport


### PR DESCRIPTION
Adding Code option as a Command Line option seems to work.  I tested several scenarios.  There are plenty of opportunities for code reuse, and I encourage that, but I needed something that would with minimal effort.  Please let me know if you will or will not merge this into your main product and release a hotfix.  If it's not going to happen, I need to know so that I can create custom builds for our developers.