### PR TITLE
Fixed problems with comment on database having same oids

### DIFF
--- a/assets/schemas/catalog/comment.sch
+++ b/assets/schemas/catalog/comment.sch
@@ -12,6 +12,10 @@
 
 [ WHERE objoid = ] {oid}
 
+%if {type-rel-name} %then
+	[ AND classoid = (SELECT oid FROM pg_class WHERE relname = ] '{type-rel-name}' )
+%end
+
 %if %not {shared-obj} %then
 	[ AND objsubid = 0 ]
 %end

--- a/libs/libconnector/src/catalog.h
+++ b/libs/libconnector/src/catalog.h
@@ -94,6 +94,9 @@ class __libconnector Catalog {
 		composed by the pg_[OBJECT_TYPE] table alias. Refer to catalog query schema files for details */
 		static std::map<ObjectType, QString> oid_fields,
 
+		/*! \brief This map stores the relation names value from pg_class table for each object type */
+		type_relnames,
+		
 		/*! \brief This map stores the name field for each object type. Refer to catalog query schema files for details */
 		name_fields,
 
@@ -161,7 +164,7 @@ class __libconnector Catalog {
 
 		/*! \brief Returns the query that is used to retrieve an objects comment. The 'is_shared_object' is used
 		to query the pg_shdescription instead of pg_description */
-		QString getCommentQuery(const QString &oid_field, bool is_shared_obj=false);
+		QString getCommentQuery(const QString &oid_field, const QString &type_relname, bool is_shared_obj=false);
 
 		//! \brief Creates a comma separated string containing all the oids to be filtered
 		QString createOidFilter(const std::vector<unsigned> &oids);

--- a/libs/libparsers/src/attributes.cpp
+++ b/libs/libparsers/src/attributes.cpp
@@ -656,6 +656,7 @@ namespace Attributes {
 	TypeClass("type-class"),
 	TypeOid("type-oid"),
 	Types("types"),
+	TypeRelationName("type-rel-name"),
 	TyplesUpd("tuples-upd"),
 	UiLanguage("ui-language"),
 	UiTheme("ui-theme"),

--- a/libs/libparsers/src/attributes.h
+++ b/libs/libparsers/src/attributes.h
@@ -670,6 +670,7 @@ namespace Attributes {
 	TypeAttribute,
 	TypeClass,
 	TypeOid,
+	TypeRelationName,
 	Types,
 	TyplesUpd,
 	UiLanguage,


### PR DESCRIPTION
According to #1773
add functionality to check object type when get comment of object during import database op.