### PR TITLE
Fix branch name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3822,7 +3822,7 @@ v0.2.0
 
 <em>Release date: August 31, 2012</em>
 
-* [New] Added an interface to implement third party plugins. Check [PLUGINS.md] (https://github.com/pgmodeler/pgmodeler/blob/master/PLUGINS.md) for details.
+* [New] Added an interface to implement third party plugins. Check [PLUGINS.md](https://github.com/pgmodeler/pgmodeler/blob/main/PLUGINS.md) for details.
 * [New] Added a short cut to easily control the zoom on the model. Use Crtl + Mouse wheel up (zoom up) or Crtl + Mouse wheel down (zoom down).
 * [Change] Due to the plugin interface the compilation method changed back to the form of shared libraries + executable.
 * [Fix] No more crashes when removing an primary-key of a table which has relationship with other tables. [(issue#2)](https://github.com/pgmodeler/pgmodeler/issues/2)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This program is free software: you can redistribute it and/or modify it under th
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
-See [LICENSE](https://github.com/pgmodeler/pgmodeler/blob/master/LICENSE) for details.
+See [LICENSE](https://github.com/pgmodeler/pgmodeler/blob/main/LICENSE) for details.
 
 :heart: pgModeler needs your support!
 -------------------
@@ -42,7 +42,7 @@ See [LICENSE](https://github.com/pgmodeler/pgmodeler/blob/master/LICENSE) for de
 :bookmark_tabs: Changelog
 ----------
 
-The detailed changelog can be seen on [CHANGELOG.md](https://github.com/pgmodeler/pgmodeler/blob/master/CHANGELOG.md) file.
+The detailed changelog can be seen on [CHANGELOG.md](https://github.com/pgmodeler/pgmodeler/blob/main/CHANGELOG.md) file.
 
 :card_file_box: Older Releases & Code
 -------------------


### PR DESCRIPTION
Use the `main` branch in links.