### PR TITLE
Crash fix after diff and closing a model

### DIFF
--- a/libs/libcore/src/baseobject.cpp
+++ b/libs/libcore/src/baseobject.cpp
@@ -1630,7 +1630,11 @@ void BaseObject::clearDependencies()
 
 void BaseObject::clearReferences()
 {
-	for(auto &obj : object_refs)
+	/* Iterate over a snapshot: unsetDependency calls back into this->unsetReference
+	 * which erases from object_refs, invalidating the range-for iterator. */
+	auto refs_snapshot = object_refs;
+
+	for(auto &obj : refs_snapshot)
 		obj->unsetDependency(this);
 
 	object_refs.clear();

--- a/libs/libcore/src/databasemodel.cpp
+++ b/libs/libcore/src/databasemodel.cpp
@@ -836,10 +836,22 @@ void DatabaseModel::destroyObjects()
 	ritr = objects.rbegin();
 	ritr_end = objects.rend();
 
+	/* Pass 1: clear all deps/refs across every object before any deletion.
+	 * This prevents dangling pointers when Relationship::destroyObjects() later
+	 * frees intermediate columns/constraints that are still referenced by other objects. */
+	while(ritr != ritr_end)
+	{
+		ritr->second->clearAllDepsRefs();
+		ritr++;
+	}
+
+	ritr = objects.rbegin();
+	ritr_end = objects.rend();
+
+	/* Pass 2: now safe to delete — no object can hold live pointers to another. */
 	while(ritr != ritr_end)
 	{
 		object = ritr->second;
-		object->clearAllDepsRefs();
 		ritr++;
 
 		// We ignore the database itself, permission objects (destroyed separetely) and table children objects


### PR DESCRIPTION
This fix resolves issue #1872 where pgmodeler was crashing after I diff and then trying to close main window.
Also this fixes another crash I started noticing on version 2.0, after opening a model and then trying to close it from menu it will crash pgmodeler.

Fix was copilot assisted and it was hard to trace because it was not reproducible when debugger was attached. So copilot added stack trace for windows (included in second commit) and from that stack trace was able to locate the problem.

Stack trace before:
```
** Stack trace unavailable on Windows system **
```
stack trace now:
```
** pgModeler crashed after receive signal: 11 **

Date/Time: 2026-03-13 11:43:19 
Version: 2.0.0-alpha1 
Build: 20260313.20260313 
Compilation Qt version: 6.10.1
Running Qt version: 6.10.1

Executable: C:\pgmodeler-2.0.0-alpha1\pgmodeler.exe

[25] pgmodeler.exe+0x6622
[24] ntdll.dll+0x8ce46
[23] ntdll.dll+0xa296f
[22] ntdll.dll+0x52554
[21] ntdll.dll+0xa147e
[20] libcore.dll+0x1d050
[19] libcore.dll+0x1190b
[18] libcore.dll+0x6d27d
[17] libcore.dll+0x6c639
[16] libcore.dll+0x6d8cd
[15] Qt6Core.dll+0xd8a50
[14] Qt6Widgets.dll+0x6058
[13] pgmodeler.exe+0x53ef
[12] Qt6Core.dll+0x91b38
[11] Qt6Core.dll+0x9587c
[10] Qt6Gui.dll+0x4769d2
[9] Qt6Core.dll+0x26d17d
[8] Qt6Gui.dll+0x4769a9
[7] Qt6Core.dll+0x9df75
[6] Qt6Core.dll+0x9b5b2
[5] pgmodeler.exe+0x26b8
[4] pgmodeler.exe+0x6d6a
[3] pgmodeler.exe+0x10d9
[2] pgmodeler.exe+0x1436
[1] KERNEL32.DLL+0x17374
[0] ntdll.dll+0x4cc91
```